### PR TITLE
[ETFE-1097] Logic added for MessageSender and MessageRecipient

### DIFF
--- a/app/uk/gov/hmrc/emcstfe/models/common/DestinationType.scala
+++ b/app/uk/gov/hmrc/emcstfe/models/common/DestinationType.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.emcstfe.models.common
+
+sealed trait DestinationType
+
+object DestinationType extends Enumerable.Implicits {
+
+  case object TaxWarehouse extends WithName("1") with DestinationType
+  case object RegisteredConsignee extends WithName("2") with DestinationType
+  case object TemporaryRegisteredConsignee extends WithName("3") with DestinationType
+  case object DirectDelivery extends WithName("4") with DestinationType
+  case object ExemptedOrganisations extends WithName("5") with DestinationType
+  case object Export extends WithName("6") with DestinationType
+  case object UnknownDestination extends WithName("8") with DestinationType
+
+  val values: Seq[DestinationType] = Seq(
+    TaxWarehouse,
+    RegisteredConsignee,
+    TemporaryRegisteredConsignee,
+    DirectDelivery,
+    ExemptedOrganisations,
+    Export,
+    UnknownDestination
+  )
+
+  implicit val enumerable: Enumerable[DestinationType] =
+    Enumerable(values.map(v => v.toString -> v): _*)
+}

--- a/app/uk/gov/hmrc/emcstfe/models/reportOfReceipt/SubmitReportOfReceiptModel.scala
+++ b/app/uk/gov/hmrc/emcstfe/models/reportOfReceipt/SubmitReportOfReceiptModel.scala
@@ -17,21 +17,22 @@
 package uk.gov.hmrc.emcstfe.models.reportOfReceipt
 
 import play.api.libs.json.{Format, Json}
-import uk.gov.hmrc.emcstfe.models.common.AcceptMovement
 import uk.gov.hmrc.emcstfe.models.common.AcceptMovement._
+import uk.gov.hmrc.emcstfe.models.common.{AcceptMovement, DestinationType}
 
 import java.time.LocalDate
 import scala.xml.{Elem, NodeSeq}
 
 case class SubmitReportOfReceiptModel(arc: String,
-                                        sequenceNumber: Int,
-                                        consigneeTrader: Option[TraderModel],
-                                        deliveryPlaceTrader: Option[TraderModel],
-                                        destinationOffice: String,
-                                        dateOfArrival: LocalDate,
-                                        acceptMovement: AcceptMovement,
-                                        individualItems: Seq[ReceiptedItemsModel],
-                                        otherInformation: Option[String]) {
+                                      sequenceNumber: Int,
+                                      destinationType: DestinationType,
+                                      consigneeTrader: Option[TraderModel],
+                                      deliveryPlaceTrader: Option[TraderModel],
+                                      destinationOffice: String,
+                                      dateOfArrival: LocalDate,
+                                      acceptMovement: AcceptMovement,
+                                      individualItems: Seq[ReceiptedItemsModel],
+                                      otherInformation: Option[String]) {
 
   val globalConclusion = acceptMovement match {
     case Satisfactory => 1

--- a/app/uk/gov/hmrc/emcstfe/models/reportOfReceipt/TraderModel.scala
+++ b/app/uk/gov/hmrc/emcstfe/models/reportOfReceipt/TraderModel.scala
@@ -29,6 +29,8 @@ case class TraderModel(traderId: Option[String],
 
   val isEmpty = traderId.isEmpty && traderName.isEmpty && (address.isEmpty || address.exists(_.isEmpty)) && eoriNumber.isEmpty
 
+  val countryCode = traderId.map(_.substring(0,2))
+
   def toXml: NodeSeq = NodeSeq.fromSeq(Seq(
     traderId.map(x => Seq(<urn:Traderid>{x}</urn:Traderid>)),
     traderName.map(x => Seq(<urn:TraderName>{x}</urn:TraderName>)),

--- a/app/uk/gov/hmrc/emcstfe/models/response/GetMovementResponse.scala
+++ b/app/uk/gov/hmrc/emcstfe/models/response/GetMovementResponse.scala
@@ -16,15 +16,16 @@
 
 package uk.gov.hmrc.emcstfe.models.response
 
-import cats.implicits.catsSyntaxTuple11Semigroupal
+import cats.implicits.catsSyntaxTuple12Semigroupal
 import com.lucidchart.open.xtract.XmlReader.strictReadSeq
 import com.lucidchart.open.xtract.{XPath, XmlReader, __}
 import play.api.libs.json.{Json, OFormat}
-import uk.gov.hmrc.emcstfe.models.common.JourneyTime
+import uk.gov.hmrc.emcstfe.models.common.{DestinationType, JourneyTime}
 import uk.gov.hmrc.emcstfe.models.reportOfReceipt.TraderModel
 
 case class GetMovementResponse(arc: String,
                                sequenceNumber: Int,
+                               destinationType: DestinationType,
                                consigneeTrader: Option[TraderModel],
                                deliveryPlaceTrader: Option[TraderModel],
                                localReferenceNumber: String,
@@ -47,6 +48,7 @@ object GetMovementResponse {
   val dateOfDispatch: XPath = EADESADContainer \ "EadEsad" \ "DateOfDispatch"
   val journeyTime: XPath = EADESADContainer \ "HeaderEadEsad" \ "JourneyTime"
   val sequenceNumber: XPath = EADESADContainer \ "HeaderEadEsad" \ "SequenceNumber"
+  val destinationTypeCode: XPath = EADESADContainer \ "HeaderEadEsad" \ "DestinationTypeCode"
   val consigneeTrader: XPath = EADESADContainer \\ "ConsigneeTrader"
   val deliveryPlaceTrader: XPath = EADESADContainer \\ "DeliveryPlaceTrader"
   val items: XPath = EADESADContainer \ "BodyEadEsad"
@@ -55,6 +57,7 @@ object GetMovementResponse {
   implicit val xmlReader: XmlReader[GetMovementResponse] = (
     arc.read[String],
     sequenceNumber.read[Int],
+    destinationTypeCode.read[DestinationType](DestinationType.xmlReads(DestinationType.enumerable)),
     consigneeTrader.read[Option[TraderModel]].map(model => if(model.exists(_.isEmpty)) None else model),
     deliveryPlaceTrader.read[Option[TraderModel]].map(model => if(model.exists(_.isEmpty)) None else model),
     localReferenceNumber.read[String],

--- a/test/uk/gov/hmrc/emcstfe/connectors/httpParsers/ChrisXMLHttpParserSpec.scala
+++ b/test/uk/gov/hmrc/emcstfe/connectors/httpParsers/ChrisXMLHttpParserSpec.scala
@@ -20,6 +20,7 @@ import com.lucidchart.open.xtract._
 import play.api.http.Status.{INTERNAL_SERVER_ERROR, OK}
 import uk.gov.hmrc.emcstfe.fixtures.GetMovementFixture
 import uk.gov.hmrc.emcstfe.mocks.utils.MockXmlUtils
+import uk.gov.hmrc.emcstfe.models.common.Enumerable.EnumerableXmlParseFailure
 import uk.gov.hmrc.emcstfe.models.common.JourneyTime.JourneyTimeParseFailure
 import uk.gov.hmrc.emcstfe.models.response.ErrorResponse.{SoapExtractionError, UnexpectedDownstreamResponseError, XmlParseError, XmlValidationError}
 import uk.gov.hmrc.emcstfe.models.response.GetMovementResponse
@@ -88,6 +89,7 @@ class ChrisXMLHttpParserSpec extends UnitSpec with MockXmlUtils with GetMovement
           result shouldBe Left(XmlParseError(Seq(
             EmptyError(GetMovementResponse.arc),
             EmptyError(GetMovementResponse.sequenceNumber),
+            EnumerableXmlParseFailure(s"Invalid enumerable value of ''"),
             EmptyError(GetMovementResponse.localReferenceNumber),
             EmptyError(GetMovementResponse.eadStatus),
             EmptyError(GetMovementResponse.consignorName),

--- a/test/uk/gov/hmrc/emcstfe/fixtures/GetMovementFixture.scala
+++ b/test/uk/gov/hmrc/emcstfe/fixtures/GetMovementFixture.scala
@@ -17,6 +17,7 @@
 package uk.gov.hmrc.emcstfe.fixtures
 
 import play.api.libs.json.{JsValue, Json}
+import uk.gov.hmrc.emcstfe.models.common.DestinationType.Export
 import uk.gov.hmrc.emcstfe.models.reportOfReceipt.{AddressModel, TraderModel}
 import uk.gov.hmrc.emcstfe.models.response.{GetMovementResponse, MovementItem, Packaging, WineProduct}
 
@@ -462,6 +463,7 @@ trait GetMovementFixture extends BaseFixtures {
   lazy val getMovementResponse: GetMovementResponse = GetMovementResponse(
     arc = "13AB7778889991ABCDEF9",
     sequenceNumber = 1,
+    destinationType = Export,
     consigneeTrader = Some(TraderModel(
       traderId = Some("GB11100000002"),
       traderName = Some("Current 801 Consignee"),
@@ -557,6 +559,7 @@ trait GetMovementFixture extends BaseFixtures {
 
   lazy val getMovementJson: JsValue = Json.obj(fields =
     "arc" -> "13AB7778889991ABCDEF9",
+    "destinationType" -> "6",
     "sequenceNumber" -> 1,
     "consigneeTrader" -> Json.obj(fields =
       "traderId" -> "GB11100000002",

--- a/test/uk/gov/hmrc/emcstfe/fixtures/GetMovementIfChangedFixture.scala
+++ b/test/uk/gov/hmrc/emcstfe/fixtures/GetMovementIfChangedFixture.scala
@@ -16,6 +16,7 @@
 
 package uk.gov.hmrc.emcstfe.fixtures
 
+import uk.gov.hmrc.emcstfe.models.common.DestinationType.Export
 import uk.gov.hmrc.emcstfe.models.reportOfReceipt.{AddressModel, TraderModel}
 import uk.gov.hmrc.emcstfe.models.response.{GetMovementResponse, MovementItem, Packaging, WineProduct}
 
@@ -490,6 +491,7 @@ trait GetMovementIfChangedFixture extends BaseFixtures {
   lazy val getMovementIfChangedResponse: GetMovementResponse = GetMovementResponse(
     arc = "13AB7778889991ABCDEF9",
     sequenceNumber = 1,
+    destinationType = Export,
     consigneeTrader = Some(TraderModel(
       traderId = Some("GB11100000002"),
       traderName = Some("Current 801 Consignee"),

--- a/test/uk/gov/hmrc/emcstfe/fixtures/SubmitReportOfReceiptFixtures.scala
+++ b/test/uk/gov/hmrc/emcstfe/fixtures/SubmitReportOfReceiptFixtures.scala
@@ -17,6 +17,7 @@
 package uk.gov.hmrc.emcstfe.fixtures
 
 import uk.gov.hmrc.emcstfe.models.common.AcceptMovement.{PartiallyRefused, Satisfactory}
+import uk.gov.hmrc.emcstfe.models.common.DestinationType.TaxWarehouse
 import uk.gov.hmrc.emcstfe.models.common.WrongWithMovement.Excess
 import uk.gov.hmrc.emcstfe.models.reportOfReceipt.SubmitReportOfReceiptModel
 
@@ -32,6 +33,7 @@ trait SubmitReportOfReceiptFixtures extends BaseFixtures
 
   val maxSubmitReportOfReceiptModel = SubmitReportOfReceiptModel(
     arc = testArc,
+    destinationType = TaxWarehouse,
     sequenceNumber = 1,
     consigneeTrader = Some(maxTraderModel),
     deliveryPlaceTrader = Some(maxTraderModel.copy(eoriNumber = None)),
@@ -49,7 +51,7 @@ trait SubmitReportOfReceiptFixtures extends BaseFixtures
     <urn:AcceptedOrRejectedReportOfReceiptExport>
       <urn:Attributes/>
       <urn:ConsigneeTrader language="en">
-        <urn:Traderid>id</urn:Traderid>
+        <urn:Traderid>{traderId}</urn:Traderid>
         <urn:TraderName>name</urn:TraderName>
         <urn:StreetName>street</urn:StreetName>
         <urn:StreetNumber>number</urn:StreetNumber>
@@ -62,7 +64,7 @@ trait SubmitReportOfReceiptFixtures extends BaseFixtures
         <urn:SequenceNumber>1</urn:SequenceNumber>
       </urn:ExciseMovement>
       <urn:DeliveryPlaceTrader language="en">
-        <urn:Traderid>id</urn:Traderid>
+        <urn:Traderid>{traderId}</urn:Traderid>
         <urn:TraderName>name</urn:TraderName>
         <urn:StreetName>street</urn:StreetName>
         <urn:StreetNumber>number</urn:StreetNumber>
@@ -100,6 +102,7 @@ trait SubmitReportOfReceiptFixtures extends BaseFixtures
 
   val minSubmitReportOfReceiptModel = SubmitReportOfReceiptModel(
     arc = testArc,
+    destinationType = TaxWarehouse,
     sequenceNumber = 1,
     consigneeTrader = None,
     deliveryPlaceTrader = None,

--- a/test/uk/gov/hmrc/emcstfe/fixtures/TraderModelFixtures.scala
+++ b/test/uk/gov/hmrc/emcstfe/fixtures/TraderModelFixtures.scala
@@ -22,8 +22,10 @@ import scala.xml.NodeSeq
 
 trait TraderModelFixtures extends BaseFixtures with AddressModelFixtures {
 
+  val traderId = "GB0000000012346"
+
   val maxTraderModel = TraderModel(
-    traderId = Some("id"),
+    traderId = Some(traderId),
     traderName = Some("name"),
     address = Some(maxAddressModel),
     eoriNumber = Some("eori")
@@ -31,7 +33,7 @@ trait TraderModelFixtures extends BaseFixtures with AddressModelFixtures {
 
   val maxTraderModelXML =
     NodeSeq.fromSeq(Seq(
-      Seq(<urn:Traderid>id</urn:Traderid>),
+      Seq(<urn:Traderid>{traderId}</urn:Traderid>),
       Seq(<urn:TraderName>name</urn:TraderName>),
       maxAddressModelXML,
       Seq(<urn:EoriNumber>eori</urn:EoriNumber>)

--- a/test/uk/gov/hmrc/emcstfe/models/common/DestinationTypeSpec.scala
+++ b/test/uk/gov/hmrc/emcstfe/models/common/DestinationTypeSpec.scala
@@ -14,14 +14,22 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.emcstfe.fixtures
+package uk.gov.hmrc.emcstfe.models.common
 
-trait BaseFixtures {
+import uk.gov.hmrc.emcstfe.models.common.DestinationType._
+import uk.gov.hmrc.emcstfe.support.UnitSpec
 
-  val testErn = "GBWK000001234"
-  val testArc: String = "23GB00000000000376967"
-  val testLrn: String = "LRN"
-  val testCredId = "cred1234567891"
-  val testInternalId = "int1234567891"
+class DestinationTypeSpec extends UnitSpec {
 
+  "DestinationType" should {
+
+    "have the correct codes" in {
+      TaxWarehouse.toString shouldBe "1"
+      RegisteredConsignee.toString shouldBe "2"
+      TemporaryRegisteredConsignee.toString shouldBe "3"
+      DirectDelivery.toString shouldBe "4"
+      ExemptedOrganisations.toString shouldBe "5"
+      Export.toString shouldBe "6"
+    }
+  }
 }


### PR DESCRIPTION
This has been based on the existing EMCS legacy portal logic here:
- https://github.com/hmrc/emcs/blob/115372605cfa20ef17f5d7248339ee47134e923e/emcs-backend/src/main/java/uk/gov/hmrc/portal/emcs/business/submission/messages/ReceiptMessage.java#L340-L369

**Note:** Requires associated frontend PR:
- https://github.com/hmrc/emcs-tfe-report-a-receipt-frontend/pull/91