### PR TITLE
ETFE-2347 Ability to search by ern & data.info.localReferenceNumber

### DIFF
--- a/app/uk/gov/hmrc/emcstfe/controllers/userAnswers/CreateMovementUserAnswersController.scala
+++ b/app/uk/gov/hmrc/emcstfe/controllers/userAnswers/CreateMovementUserAnswersController.scala
@@ -62,4 +62,13 @@ class CreateMovementUserAnswersController @Inject()(cc: ControllerComponents,
           case Left(mongoError) => InternalServerError(Json.toJson(mongoError))
         }
     }
+
+  def checkForExistingLrn(ern: String, lrn: String): Action[AnyContent] =
+    authorisedUserRequest(ern) {
+      _ =>
+        createMovementUserAnswersService.checkForExistingLrn(ern, lrn) map {
+          case Right(exists) => Ok(Json.toJson(exists))
+          case Left(mongoError) => InternalServerError(Json.toJson(mongoError))
+        }
+    }
 }

--- a/app/uk/gov/hmrc/emcstfe/repositories/CreateMovementUserAnswersRepository.scala
+++ b/app/uk/gov/hmrc/emcstfe/repositories/CreateMovementUserAnswersRepository.scala
@@ -43,6 +43,8 @@ trait CreateMovementUserAnswersRepository {
   def set(answers: CreateMovementUserAnswers): Future[Boolean]
 
   def clear(ern: String, draftId: String): Future[Boolean]
+
+  def checkForExistingLrn(ern: String, lrn: String): Future[Boolean]
 }
 
 @Singleton
@@ -102,6 +104,18 @@ class CreateMovementUserAnswersRepositoryImpl @Inject()(mongoComponent: MongoCom
       .deleteOne(by(ern, draftId))
       .toFuture()
       .map(_ => true)
+
+  def checkForExistingLrn(ern: String, lrn: String): Future[Boolean] =
+    collection
+      .find(
+        Filters.and(
+          Filters.equal("ern", ern),
+          Filters.equal("data.info.localReferenceNumber", lrn)
+        )
+      )
+      .headOption()
+      .map(_.isDefined)
+
 }
 
 object CreateMovementUserAnswersRepository {

--- a/app/uk/gov/hmrc/emcstfe/services/userAnswers/CreateMovementUserAnswersService.scala
+++ b/app/uk/gov/hmrc/emcstfe/services/userAnswers/CreateMovementUserAnswersService.scala
@@ -36,4 +36,8 @@ class CreateMovementUserAnswersService @Inject()(repo: CreateMovementUserAnswers
 
   def clear(ern: String, draftId: String)(implicit ec: ExecutionContext): Future[Either[ErrorResponse, Boolean]] =
     repo.clear(ern, draftId).map(Right(_)).recover(recovery)
+
+  def checkForExistingLrn(ern: String, lrn: String)(implicit ec: ExecutionContext): Future[Either[ErrorResponse, Boolean]] =
+    repo.checkForExistingLrn(ern, lrn).map(answers => Right(answers)).recover(recovery)
+
 }

--- a/conf/userAnswers.routes
+++ b/conf/userAnswers.routes
@@ -7,6 +7,7 @@ DELETE        /report-receipt/:ern/:arc                    uk.gov.hmrc.emcstfe.c
 GET           /create-movement/:ern/:draftId               uk.gov.hmrc.emcstfe.controllers.userAnswers.CreateMovementUserAnswersController.get(ern, draftId)
 PUT           /create-movement/:ern/:draftId               uk.gov.hmrc.emcstfe.controllers.userAnswers.CreateMovementUserAnswersController.set(ern, draftId)
 DELETE        /create-movement/:ern/:draftId               uk.gov.hmrc.emcstfe.controllers.userAnswers.CreateMovementUserAnswersController.clear(ern, draftId)
+GET           /create-movement/trader/:ern/lrn/:lrn        uk.gov.hmrc.emcstfe.controllers.userAnswers.CreateMovementUserAnswersController.checkForExistingLrn(ern, lrn)
 
 DELETE        /explain-delay/:ern/:arc                     uk.gov.hmrc.emcstfe.controllers.userAnswers.ExplainDelayUserAnswersController.clear(ern, arc)
 GET           /explain-delay/:ern/:arc                     uk.gov.hmrc.emcstfe.controllers.userAnswers.ExplainDelayUserAnswersController.get(ern, arc)

--- a/it/uk/gov/hmrc/emcstfe/repositories/CreateMovementUserAnswersRepositorySpec.scala
+++ b/it/uk/gov/hmrc/emcstfe/repositories/CreateMovementUserAnswersRepositorySpec.scala
@@ -130,4 +130,20 @@ class CreateMovementUserAnswersRepositorySpec extends RepositoryBaseSpec[CreateM
       }
     }
   }
+
+  ".checkForExistingLrn" must {
+
+    "there is a record with this ern and lrn" in {
+      val lrnEntry = userAnswers.copy(data = Json.obj("info" -> Json.obj("localReferenceNumber" -> "LRN1234")))
+      insert(lrnEntry).futureValue
+      repository.checkForExistingLrn(userAnswers.ern, "LRN1234").futureValue shouldBe true
+    }
+
+    "there is no record with this ern and lrn" in {
+      val lrnEntry = userAnswers.copy(data = Json.obj("info" -> Json.obj("localReferenceNumber" -> "LRN1234")))
+      insert(lrnEntry).futureValue
+      repository.checkForExistingLrn(userAnswers.ern, "ABC1234").futureValue shouldBe false
+    }
+
+  }
 }

--- a/test/uk/gov/hmrc/emcstfe/controllers/userAnswers/CreateMovementUserAnswersControllerSpec.scala
+++ b/test/uk/gov/hmrc/emcstfe/controllers/userAnswers/CreateMovementUserAnswersControllerSpec.scala
@@ -79,6 +79,41 @@ class CreateMovementUserAnswersControllerSpec extends TestBaseSpec with MockCrea
     }
   }
 
+  "GET /user-answers/create-movement/trader/:ern/lrn/:lrn" should {
+    s"return $OK (OK)" when {
+
+      "service returns a Right(true)" in {
+        MockUserAnswers.checkForExistingLrn(testErn, testLrn).returns(Future.successful(Right(true)))
+
+        val result = controller.checkForExistingLrn(testErn, testLrn)(fakeRequest)
+
+        status(result) shouldBe Status.OK
+        contentAsJson(result) shouldBe Json.toJson(true)
+      }
+
+      "service returns a Right(false)" in {
+        MockUserAnswers.checkForExistingLrn(testErn, testLrn).returns(Future.successful(Right(false)))
+
+        val result = controller.checkForExistingLrn(testErn, testLrn)(fakeRequest)
+
+        status(result) shouldBe Status.OK
+        contentAsJson(result) shouldBe Json.toJson(false)
+      }
+    }
+
+    s"return $INTERNAL_SERVER_ERROR (ISE)" when {
+      "service returns a Left" in {
+
+        MockUserAnswers.checkForExistingLrn(testErn, testLrn).returns(Future.successful(Left(MongoError("errMsg"))))
+
+        val result = controller.checkForExistingLrn(testErn, testLrn)(fakeRequest)
+
+        status(result) shouldBe Status.INTERNAL_SERVER_ERROR
+        contentAsJson(result) shouldBe Json.toJson(MongoError("errMsg"))
+      }
+    }
+  }
+
   "PUT /user-answers/report-receipt/:ern/:lrn" should {
     s"return $OK (OK)" when {
       "service stores the new model returns a Right(answers)" in {

--- a/test/uk/gov/hmrc/emcstfe/fixtures/BaseFixtures.scala
+++ b/test/uk/gov/hmrc/emcstfe/fixtures/BaseFixtures.scala
@@ -20,6 +20,7 @@ trait BaseFixtures {
 
   val testErn = "GBWK000001234"
   val testArc: String = "23GB00000000000376967"
+  val testLrn: String = "LRN"
   val testDraftId: String = "1234-5678-9012"
   val testCredId = "cred1234567891"
   val testInternalId = "int1234567891"

--- a/test/uk/gov/hmrc/emcstfe/mocks/repository/MockCreateMovementUserAnswersRepository.scala
+++ b/test/uk/gov/hmrc/emcstfe/mocks/repository/MockCreateMovementUserAnswersRepository.scala
@@ -35,6 +35,9 @@ trait MockCreateMovementUserAnswersRepository extends MockFactory {
 
     def clear(ern: String, lrn: String): CallHandler2[String, String, Future[Boolean]] =
       (mockRepo.clear(_: String, _: String)).expects(ern, lrn)
+
+    def checkForExistingLrn(ern: String, lrn: String): CallHandler2[String, String, Future[Boolean]] =
+      (mockRepo.checkForExistingLrn(_: String, _: String)).expects(ern, lrn)
   }
 }
 

--- a/test/uk/gov/hmrc/emcstfe/mocks/services/MockCreateMovementUserAnswersService.scala
+++ b/test/uk/gov/hmrc/emcstfe/mocks/services/MockCreateMovementUserAnswersService.scala
@@ -37,6 +37,9 @@ trait MockCreateMovementUserAnswersService extends MockFactory  {
 
     def clear(ern: String, lrn: String): CallHandler3[String, String, ExecutionContext, Future[Either[ErrorResponse, Boolean]]] =
       (mockService.clear(_: String, _: String)(_: ExecutionContext)).expects(ern, lrn, *)
+
+    def checkForExistingLrn(ern: String, lrn: String): CallHandler3[String, String, ExecutionContext, Future[Either[ErrorResponse, Boolean]]] =
+      (mockService.checkForExistingLrn(_: String, _: String)(_: ExecutionContext)).expects(ern, lrn, *)
   }
 }
 

--- a/test/uk/gov/hmrc/emcstfe/services/userAnswers/CreateMovementUserAnswersServiceSpec.scala
+++ b/test/uk/gov/hmrc/emcstfe/services/userAnswers/CreateMovementUserAnswersServiceSpec.scala
@@ -92,4 +92,28 @@ class CreateMovementUserAnswersServiceSpec extends TestBaseSpec with GetMovement
       }
     }
   }
+
+  ".checkForExistingLrn" should {
+    "return a Right(true)" when {
+      "there is already a draft with the ERN and LRN" in new Test {
+        MockRepository.checkForExistingLrn(testErn, testLrn).returns(Future.successful(true))
+        await(service.checkForExistingLrn(testErn, testLrn)) shouldBe Right(true)
+      }
+    }
+
+    "return a Right(false)" when {
+      "there isn't a draft with the ERN and LRN" in new Test {
+        MockRepository.checkForExistingLrn(testErn, testLrn).returns(Future.successful(false))
+        await(service.checkForExistingLrn(testErn, testLrn)) shouldBe Right(false)
+      }
+    }
+
+    "return a Left" when {
+      "mongo error is returned" in new Test {
+
+        MockRepository.checkForExistingLrn(testErn, testLrn).returns(Future.failed(new Exception("bang")))
+        await(service.checkForExistingLrn(testErn, testLrn)) shouldBe Left(MongoError("bang"))
+      }
+    }
+  }
 }


### PR DESCRIPTION
Introduce the ability to search for a draft by checking the ERN and the LRN within the `data.info.localReferenceNumber` data section. 

```
{
    "_id" : ObjectId("65365c4e6a13e1e90e90418e"),
    "ern" : "GBWK001234569",
    "draftId" : "f2f499b0-5a01-4773-885b-49dc1452267c",
    "data" : {
        "info" : {
            "destinationType" : "gbTaxWarehouse",
            "deferredMovement" : true,
            "localReferenceNumber" : "1000"
        }
    },
    "lastUpdated" : ISODate("2023-10-23T11:43:10.137+0000")
}
```