### PR TITLE
ETFE-3009 Remove whitespace from CDATA XML

### DIFF
--- a/app/uk/gov/hmrc/emcstfe/models/common/MovementGuaranteeModel.scala
+++ b/app/uk/gov/hmrc/emcstfe/models/common/MovementGuaranteeModel.scala
@@ -32,9 +32,7 @@ case class MovementGuaranteeModel(
     with XmlWriterUtils {
 
   def toXml(implicit request: UserRequest[_]): Elem = <urn:MovementGuarantee>
-    <urn:GuarantorTypeCode>
-      {guarantorTypeCode.toString}
-    </urn:GuarantorTypeCode>
+    <urn:GuarantorTypeCode>{guarantorTypeCode.toString}</urn:GuarantorTypeCode>
     {guarantorTrader.mapNodeSeq(_.map(trader => <urn:GuarantorTrader language="en">{trader.toXml(GuarantorTrader)}</urn:GuarantorTrader>))}
   </urn:MovementGuarantee>
 

--- a/app/uk/gov/hmrc/emcstfe/models/request/SoapEnvelope.scala
+++ b/app/uk/gov/hmrc/emcstfe/models/request/SoapEnvelope.scala
@@ -38,39 +38,21 @@ trait SoapEnvelope { _: ChrisRequest =>
          |      <ns:ServiceMessageType>HMRC-EMCS-IE$messageNumber-DIRECT</ns:ServiceMessageType>
          |    </ns:Info>
          |    <MetaData xmlns="http://www.hmrc.gov.uk/ChRIS/SOAP/MetaData/1">
-         |      <CredentialID>
-         |        ${request.credId}
-         |      </CredentialID>
-         |      <Identifier>
-         |        ${request.ern}
-         |      </Identifier>
+         |      <CredentialID>${request.credId}</CredentialID>
+         |      <Identifier>${request.ern}</Identifier>
          |    </MetaData>
          |  </soapenv:Header>
          |  <soapenv:Body>
          |    <urn:IE$messageNumber xmlns:urn="urn:publicid:-:EC:DGTAXUD:EMCS:PHASE4:IE$messageNumber:V3.01" xmlns:urn1="urn:publicid:-:EC:DGTAXUD:EMCS:PHASE4:TMS:V3.01">
          |      <urn:Header>
-         |        <urn1:MessageSender>
-         |          $messageSender
-         |        </urn1:MessageSender>
-         |        <urn1:MessageRecipient>
-         |          $messageRecipient
-         |        </urn1:MessageRecipient>
-         |        <urn1:DateOfPreparation>
-         |          ${preparedDate.toString}
-         |        </urn1:DateOfPreparation>
-         |        <urn1:TimeOfPreparation>
-         |          ${preparedTime.toString}
-         |        </urn1:TimeOfPreparation>
-         |        <urn1:MessageIdentifier>
-         |          $messageUUID
-         |        </urn1:MessageIdentifier>
-         |        <urn1:CorrelationIdentifier>
-         |          $legacyCorrelationUUID
-         |        </urn1:CorrelationIdentifier>
+         |        <urn1:MessageSender>$messageSender</urn1:MessageSender>
+         |        <urn1:MessageRecipient>$messageRecipient</urn1:MessageRecipient>
+         |        <urn1:DateOfPreparation>${preparedDate.toString}</urn1:DateOfPreparation>
+         |        <urn1:TimeOfPreparation>${preparedTime.toString}</urn1:TimeOfPreparation>
+         |        <urn1:MessageIdentifier>$messageUUID</urn1:MessageIdentifier>
+         |        <urn1:CorrelationIdentifier>$legacyCorrelationUUID</urn1:CorrelationIdentifier>
          |      </urn:Header>
-         |      <urn:Body>
-         |        ${body.toXml}
-         |      </urn:Body>
+         |      <urn:Body>${body.toXml}</urn:Body>
          |    </urn:IE$messageNumber>
          |  </soapenv:Body>
          |</soapenv:Envelope>""".stripMargin)

--- a/app/uk/gov/hmrc/emcstfe/models/request/SoapEnvelope.scala
+++ b/app/uk/gov/hmrc/emcstfe/models/request/SoapEnvelope.scala
@@ -29,31 +29,31 @@ trait SoapEnvelope { _: ChrisRequest =>
                                           messageRecipient: String)(implicit request: UserRequest[_]): Elem =
     XML.loadString(
       s"""<soapenv:Envelope xmlns:soapenv="http://www.w3.org/2003/05/soap-envelope">
-         |  <soapenv:Header>
-         |    <ns:Info xmlns:ns="http://www.hmrc.gov.uk/ws/info-header/1">
-         |      <ns:VendorName>EMCS_PORTAL_TFE</ns:VendorName>
-         |      <ns:VendorID>1259</ns:VendorID>
-         |      <ns:VendorProduct Version="2.0">HMRC Portal</ns:VendorProduct>
-         |      <ns:ServiceID>1138</ns:ServiceID>
-         |      <ns:ServiceMessageType>HMRC-EMCS-IE$messageNumber-DIRECT</ns:ServiceMessageType>
-         |    </ns:Info>
-         |    <MetaData xmlns="http://www.hmrc.gov.uk/ChRIS/SOAP/MetaData/1">
-         |      <CredentialID>${request.credId}</CredentialID>
-         |      <Identifier>${request.ern}</Identifier>
-         |    </MetaData>
-         |  </soapenv:Header>
-         |  <soapenv:Body>
-         |    <urn:IE$messageNumber xmlns:urn="urn:publicid:-:EC:DGTAXUD:EMCS:PHASE4:IE$messageNumber:V3.01" xmlns:urn1="urn:publicid:-:EC:DGTAXUD:EMCS:PHASE4:TMS:V3.01">
-         |      <urn:Header>
-         |        <urn1:MessageSender>$messageSender</urn1:MessageSender>
-         |        <urn1:MessageRecipient>$messageRecipient</urn1:MessageRecipient>
-         |        <urn1:DateOfPreparation>${preparedDate.toString}</urn1:DateOfPreparation>
-         |        <urn1:TimeOfPreparation>${preparedTime.toString}</urn1:TimeOfPreparation>
-         |        <urn1:MessageIdentifier>$messageUUID</urn1:MessageIdentifier>
-         |        <urn1:CorrelationIdentifier>$legacyCorrelationUUID</urn1:CorrelationIdentifier>
-         |      </urn:Header>
-         |      <urn:Body>${body.toXml}</urn:Body>
-         |    </urn:IE$messageNumber>
-         |  </soapenv:Body>
+         |<soapenv:Header>
+         |<ns:Info xmlns:ns="http://www.hmrc.gov.uk/ws/info-header/1">
+         |<ns:VendorName>EMCS_PORTAL_TFE</ns:VendorName>
+         |<ns:VendorID>1259</ns:VendorID>
+         |<ns:VendorProduct Version="2.0">HMRC Portal</ns:VendorProduct>
+         |<ns:ServiceID>1138</ns:ServiceID>
+         |<ns:ServiceMessageType>HMRC-EMCS-IE$messageNumber-DIRECT</ns:ServiceMessageType>
+         |</ns:Info>
+         |<MetaData xmlns="http://www.hmrc.gov.uk/ChRIS/SOAP/MetaData/1">
+         |<CredentialID>${request.credId}</CredentialID>
+         |<Identifier>${request.ern}</Identifier>
+         |</MetaData>
+         |</soapenv:Header>
+         |<soapenv:Body>
+         |<urn:IE$messageNumber xmlns:urn="urn:publicid:-:EC:DGTAXUD:EMCS:PHASE4:IE$messageNumber:V3.01" xmlns:urn1="urn:publicid:-:EC:DGTAXUD:EMCS:PHASE4:TMS:V3.01">
+         |<urn:Header>
+         |<urn1:MessageSender>$messageSender</urn1:MessageSender>
+         |<urn1:MessageRecipient>$messageRecipient</urn1:MessageRecipient>
+         |<urn1:DateOfPreparation>${preparedDate.toString}</urn1:DateOfPreparation>
+         |<urn1:TimeOfPreparation>${preparedTime.toString}</urn1:TimeOfPreparation>
+         |<urn1:MessageIdentifier>$messageUUID</urn1:MessageIdentifier>
+         |<urn1:CorrelationIdentifier>$legacyCorrelationUUID</urn1:CorrelationIdentifier>
+         |</urn:Header>
+         |<urn:Body>${body.toXml}</urn:Body>
+         |</urn:IE$messageNumber>
+         |</soapenv:Body>
          |</soapenv:Envelope>""".stripMargin)
 }

--- a/app/uk/gov/hmrc/emcstfe/models/request/eis/EisMessage.scala
+++ b/app/uk/gov/hmrc/emcstfe/models/request/eis/EisMessage.scala
@@ -32,15 +32,15 @@ trait EisMessage extends XmlWriterUtils {
     trimWhitespaceFromXml(controlDocument(
       XML.loadString(
         s"""<urn:IE$messageNumber xmlns:urn="urn:publicid:-:EC:DGTAXUD:EMCS:PHASE4:IE$messageNumber:V3.01" xmlns:urn1="urn:publicid:-:EC:DGTAXUD:EMCS:PHASE4:TMS:V3.01">
-           |  <urn:Header>
-           |    <urn1:MessageSender>$messageSender</urn1:MessageSender>
-           |    <urn1:MessageRecipient>$messageRecipient</urn1:MessageRecipient>
-           |    <urn1:DateOfPreparation>${preparedDate.toString}</urn1:DateOfPreparation>
-           |    <urn1:TimeOfPreparation>${preparedTime.toString}</urn1:TimeOfPreparation>
-           |    <urn1:MessageIdentifier>$messageUUID</urn1:MessageIdentifier>
-           |    <urn1:CorrelationIdentifier>$correlationUUID</urn1:CorrelationIdentifier>
-           |  </urn:Header>
-           |  <urn:Body>${body.toXml}</urn:Body>
+           |<urn:Header>
+           |<urn1:MessageSender>$messageSender</urn1:MessageSender>
+           |<urn1:MessageRecipient>$messageRecipient</urn1:MessageRecipient>
+           |<urn1:DateOfPreparation>${preparedDate.toString}</urn1:DateOfPreparation>
+           |<urn1:TimeOfPreparation>${preparedTime.toString}</urn1:TimeOfPreparation>
+           |<urn1:MessageIdentifier>$messageUUID</urn1:MessageIdentifier>
+           |<urn1:CorrelationIdentifier>$correlationUUID</urn1:CorrelationIdentifier>
+           |</urn:Header>
+           |<urn:Body>${body.toXml}</urn:Body>
            |</urn:IE$messageNumber>""".stripMargin)
     )).toString()
 

--- a/app/uk/gov/hmrc/emcstfe/models/request/eis/EisMessage.scala
+++ b/app/uk/gov/hmrc/emcstfe/models/request/eis/EisMessage.scala
@@ -33,28 +33,14 @@ trait EisMessage extends XmlWriterUtils {
       XML.loadString(
         s"""<urn:IE$messageNumber xmlns:urn="urn:publicid:-:EC:DGTAXUD:EMCS:PHASE4:IE$messageNumber:V3.01" xmlns:urn1="urn:publicid:-:EC:DGTAXUD:EMCS:PHASE4:TMS:V3.01">
            |  <urn:Header>
-           |    <urn1:MessageSender>
-           |      $messageSender
-           |    </urn1:MessageSender>
-           |    <urn1:MessageRecipient>
-           |      $messageRecipient
-           |    </urn1:MessageRecipient>
-           |    <urn1:DateOfPreparation>
-           |      ${preparedDate.toString}
-           |    </urn1:DateOfPreparation>
-           |    <urn1:TimeOfPreparation>
-           |      ${preparedTime.toString}
-           |    </urn1:TimeOfPreparation>
-           |    <urn1:MessageIdentifier>
-           |      $messageUUID
-           |    </urn1:MessageIdentifier>
-           |    <urn1:CorrelationIdentifier>
-           |      $correlationUUID
-           |    </urn1:CorrelationIdentifier>
+           |    <urn1:MessageSender>$messageSender</urn1:MessageSender>
+           |    <urn1:MessageRecipient>$messageRecipient</urn1:MessageRecipient>
+           |    <urn1:DateOfPreparation>${preparedDate.toString}</urn1:DateOfPreparation>
+           |    <urn1:TimeOfPreparation>${preparedTime.toString}</urn1:TimeOfPreparation>
+           |    <urn1:MessageIdentifier>$messageUUID</urn1:MessageIdentifier>
+           |    <urn1:CorrelationIdentifier>$correlationUUID</urn1:CorrelationIdentifier>
            |  </urn:Header>
-           |  <urn:Body>
-           |    ${body.toXml}
-           |  </urn:Body>
+           |  <urn:Body>${body.toXml}</urn:Body>
            |</urn:IE$messageNumber>""".stripMargin)
     )).toString()
 
@@ -69,9 +55,7 @@ trait EisMessage extends XmlWriterUtils {
       <con:OperationRequest>
         <con:Parameters>
           <con:Parameter Name="ExciseRegistrationNumber">{exciseRegistrationNumber}</con:Parameter>
-          <con:Parameter Name="message">
-            {PCData(xml.toString())}
-          </con:Parameter>
+          <con:Parameter Name="message">{PCData(xml.toString())}</con:Parameter>
         </con:Parameters>
         <con:ReturnData/>
       </con:OperationRequest>


### PR DESCRIPTION
The **_trimWhiteSpace_** call will not trim any whitespace within the CDATA section of XML as XML parsers will read this section as character data and not XML markup, therefore **_trimWhiteSpace_** will leave it alone. So I've manually removed the additional spaces.