### PR TITLE
[ETFE-3631] Add NRS event for Create Movement

### DIFF
--- a/app/uk/gov/hmrc/emcstfe/controllers/SubmitAlertOrRejectionController.scala
+++ b/app/uk/gov/hmrc/emcstfe/controllers/SubmitAlertOrRejectionController.scala
@@ -23,7 +23,6 @@ import uk.gov.hmrc.emcstfe.controllers.actions.{AuthAction, AuthActionHelper}
 import uk.gov.hmrc.emcstfe.featureswitch.core.config.{EnableNRS, FeatureSwitching, SendToEIS}
 import uk.gov.hmrc.emcstfe.models.alertOrRejection.SubmitAlertOrRejectionModel
 import uk.gov.hmrc.emcstfe.models.auth.UserRequest
-import uk.gov.hmrc.emcstfe.models.nrs.NotableEvent.AlertRejectNotableEvent
 import uk.gov.hmrc.emcstfe.models.nrs.alertReject.AlertRejectNRSSubmission
 import uk.gov.hmrc.emcstfe.models.response.ErrorResponse
 import uk.gov.hmrc.emcstfe.services.SubmitAlertOrRejectionService
@@ -47,8 +46,7 @@ class SubmitAlertOrRejectionController @Inject()(cc: ControllerComponents,
     withJsonBody[SubmitAlertOrRejectionModel] {
       submission =>
         if(isEnabled(EnableNRS)) {
-          val nrsSubmissionModel = AlertRejectNRSSubmission.apply(submission)
-          nrsBrokerService.submitPayload(nrsSubmissionModel, ern, AlertRejectNotableEvent).flatMap(_ => handleSubmission(submission))
+          nrsBrokerService.submitPayload(AlertRejectNRSSubmission(submission), ern).flatMap(_ => handleSubmission(submission))
         } else {
           handleSubmission(submission)
         }

--- a/app/uk/gov/hmrc/emcstfe/controllers/SubmitCancellationOfMovementController.scala
+++ b/app/uk/gov/hmrc/emcstfe/controllers/SubmitCancellationOfMovementController.scala
@@ -23,7 +23,6 @@ import uk.gov.hmrc.emcstfe.controllers.actions.{AuthAction, AuthActionHelper}
 import uk.gov.hmrc.emcstfe.featureswitch.core.config.{EnableNRS, FeatureSwitching, SendToEIS}
 import uk.gov.hmrc.emcstfe.models.auth.UserRequest
 import uk.gov.hmrc.emcstfe.models.cancellationOfMovement.SubmitCancellationOfMovementModel
-import uk.gov.hmrc.emcstfe.models.nrs.NotableEvent.CancelMovementNotableEvent
 import uk.gov.hmrc.emcstfe.models.nrs.cancelMovement.CancelMovementNRSSubmission
 import uk.gov.hmrc.emcstfe.models.response.ErrorResponse
 import uk.gov.hmrc.emcstfe.services.SubmitCancellationOfMovementService
@@ -48,8 +47,7 @@ class SubmitCancellationOfMovementController @Inject()(cc: ControllerComponents,
         withJsonBody[SubmitCancellationOfMovementModel] {
           submission =>
             if(isEnabled(EnableNRS)) {
-              val nrsSubmissionModel = CancelMovementNRSSubmission.apply(submission, ern)
-              nrsBrokerService.submitPayload(nrsSubmissionModel, ern, CancelMovementNotableEvent).flatMap(_ => handleSubmission(submission))
+              nrsBrokerService.submitPayload(CancelMovementNRSSubmission(submission, ern), ern).flatMap(_ => handleSubmission(submission))
             } else {
               handleSubmission(submission)
             }

--- a/app/uk/gov/hmrc/emcstfe/controllers/SubmitCreateMovementController.scala
+++ b/app/uk/gov/hmrc/emcstfe/controllers/SubmitCreateMovementController.scala
@@ -20,12 +20,16 @@ import play.api.libs.json.{JsValue, Json, Writes}
 import play.api.mvc.{Action, ControllerComponents, Result}
 import uk.gov.hmrc.emcstfe.config.AppConfig
 import uk.gov.hmrc.emcstfe.controllers.actions.{AuthAction, AuthActionHelper}
-import uk.gov.hmrc.emcstfe.featureswitch.core.config.{DefaultDraftMovementCorrelationId, FeatureSwitching, SendToEIS, ValidateUsingFS41Schema}
+import uk.gov.hmrc.emcstfe.featureswitch.core.config._
+import uk.gov.hmrc.emcstfe.models.auth.UserRequest
 import uk.gov.hmrc.emcstfe.models.createMovement.SubmitCreateMovementModel
+import uk.gov.hmrc.emcstfe.models.nrs.createMovement.CreateMovementNRSSubmission
 import uk.gov.hmrc.emcstfe.models.request.SubmitCreateMovementRequest
 import uk.gov.hmrc.emcstfe.models.response.ErrorResponse
 import uk.gov.hmrc.emcstfe.services.SubmitCreateMovementService
+import uk.gov.hmrc.emcstfe.services.nrs.NRSBrokerService
 import uk.gov.hmrc.emcstfe.utils.Logging
+import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
 import javax.inject.{Inject, Singleton}
@@ -34,24 +38,37 @@ import scala.concurrent.{ExecutionContext, Future}
 @Singleton()
 class SubmitCreateMovementController @Inject()(cc: ControllerComponents,
                                                service: SubmitCreateMovementService,
+                                               nrsBrokerService: NRSBrokerService,
                                                val config: AppConfig,
                                                override val auth: AuthAction
                                               )(implicit ec: ExecutionContext) extends BackendController(cc) with AuthActionHelper with Logging with FeatureSwitching {
 
   def submit(ern: String, draftId: String): Action[JsValue] = authorisedUserSubmissionRequest(ern) { implicit request =>
     withJsonBody[SubmitCreateMovementModel] { submission =>
-      val isEISFeatureEnabled = isEnabled(SendToEIS)
-      val requestModel = SubmitCreateMovementRequest(submission, draftId, isEnabled(ValidateUsingFS41Schema), isChRISSubmission = !isEISFeatureEnabled)
-      val correlationId = getCorrelationId(isEISFeatureEnabled, isEnabled(DefaultDraftMovementCorrelationId), requestModel)
-      if (isEISFeatureEnabled) {
-        service.submitViaEIS(requestModel).flatMap(responseModel => handleResponse(responseModel.map(_.copy(
-          submittedDraftId = Some(correlationId))), ern, draftId, correlationId
-        ))
+      if (isEnabled(EnableNRS)) {
+        nrsBrokerService.submitPayload(CreateMovementNRSSubmission(ern, submission), ern).flatMap(_ =>
+          handleSubmission(ern, draftId, submission)
+        )
       } else {
-        service.submit(requestModel).flatMap(responseModel => handleResponse(responseModel.map(_.copy(
-          submittedDraftId = Some(correlationId))), ern, draftId, correlationId
-        ))
+        handleSubmission(ern, draftId, submission)
       }
+    }
+  }
+
+  private def handleSubmission(ern: String, draftId: String, submission: SubmitCreateMovementModel)(implicit hc: HeaderCarrier, ec: ExecutionContext, req: UserRequest[_]): Future[Result] = {
+
+    val sendToEIS = isEnabled(SendToEIS)
+    val request = SubmitCreateMovementRequest(submission, draftId, isEnabled(ValidateUsingFS41Schema), isChRISSubmission = !sendToEIS)
+    val correlationId = getCorrelationId(sendToEIS, isEnabled(DefaultDraftMovementCorrelationId), request)
+
+    if (sendToEIS) {
+      service.submitViaEIS(request).flatMap(responseModel => handleResponse(responseModel.map(_.copy(
+        submittedDraftId = Some(correlationId))), ern, draftId, correlationId
+      ))
+    } else {
+      service.submit(request).flatMap(responseModel => handleResponse(responseModel.map(_.copy(
+        submittedDraftId = Some(correlationId))), ern, draftId, correlationId
+      ))
     }
   }
 

--- a/app/uk/gov/hmrc/emcstfe/controllers/SubmitExplainDelayController.scala
+++ b/app/uk/gov/hmrc/emcstfe/controllers/SubmitExplainDelayController.scala
@@ -23,7 +23,6 @@ import uk.gov.hmrc.emcstfe.controllers.actions.{AuthAction, AuthActionHelper}
 import uk.gov.hmrc.emcstfe.featureswitch.core.config.{EnableNRS, FeatureSwitching, SendToEIS}
 import uk.gov.hmrc.emcstfe.models.auth.UserRequest
 import uk.gov.hmrc.emcstfe.models.explainDelay.SubmitExplainDelayModel
-import uk.gov.hmrc.emcstfe.models.nrs.NotableEvent.ExplainDelayNotableEvent
 import uk.gov.hmrc.emcstfe.models.nrs.explainDelay.ExplainDelayNRSSubmission
 import uk.gov.hmrc.emcstfe.models.response.ErrorResponse
 import uk.gov.hmrc.emcstfe.services.SubmitExplainDelayService
@@ -48,8 +47,7 @@ class SubmitExplainDelayController @Inject()(cc: ControllerComponents,
       withJsonBody[SubmitExplainDelayModel] {
         submission =>
           if (isEnabled(EnableNRS)) {
-            val nrsSubmissionModel = ExplainDelayNRSSubmission.apply(submission)
-            nrsBrokerService.submitPayload(nrsSubmissionModel, ern, ExplainDelayNotableEvent).flatMap(_ => handleSubmission(submission))
+            nrsBrokerService.submitPayload(ExplainDelayNRSSubmission(submission), ern).flatMap(_ => handleSubmission(submission))
           } else {
             handleSubmission(submission)
           }

--- a/app/uk/gov/hmrc/emcstfe/controllers/SubmitExplainShortageExcessController.scala
+++ b/app/uk/gov/hmrc/emcstfe/controllers/SubmitExplainShortageExcessController.scala
@@ -23,7 +23,6 @@ import uk.gov.hmrc.emcstfe.controllers.actions.{AuthAction, AuthActionHelper}
 import uk.gov.hmrc.emcstfe.featureswitch.core.config.{EnableNRS, FeatureSwitching, SendToEIS}
 import uk.gov.hmrc.emcstfe.models.auth.UserRequest
 import uk.gov.hmrc.emcstfe.models.explainShortageExcess.SubmitExplainShortageExcessModel
-import uk.gov.hmrc.emcstfe.models.nrs.NotableEvent.ExplainShortageOrExcessNotableEvent
 import uk.gov.hmrc.emcstfe.models.nrs.explainShortageExcess.ExplainShortageExcessNRSSubmission
 import uk.gov.hmrc.emcstfe.models.response.ErrorResponse
 import uk.gov.hmrc.emcstfe.services.SubmitExplainShortageExcessService
@@ -48,8 +47,7 @@ class SubmitExplainShortageExcessController @Inject()(cc: ControllerComponents,
       withJsonBody[SubmitExplainShortageExcessModel] {
         submission =>
           if(isEnabled(EnableNRS)) {
-            val nrsSubmissionModel = ExplainShortageExcessNRSSubmission.apply(submission, ern)
-            nrsBrokerService.submitPayload(nrsSubmissionModel, ern, ExplainShortageOrExcessNotableEvent).flatMap(_ => handleSubmission(submission))
+            nrsBrokerService.submitPayload(ExplainShortageExcessNRSSubmission(submission, ern), ern).flatMap(_ => handleSubmission(submission))
           } else {
             handleSubmission(submission)
           }

--- a/app/uk/gov/hmrc/emcstfe/controllers/SubmitReportOfReceiptController.scala
+++ b/app/uk/gov/hmrc/emcstfe/controllers/SubmitReportOfReceiptController.scala
@@ -22,7 +22,6 @@ import uk.gov.hmrc.emcstfe.config.AppConfig
 import uk.gov.hmrc.emcstfe.controllers.actions.{AuthAction, AuthActionHelper}
 import uk.gov.hmrc.emcstfe.featureswitch.core.config.{EnableNRS, FeatureSwitching, SendToEIS}
 import uk.gov.hmrc.emcstfe.models.auth.UserRequest
-import uk.gov.hmrc.emcstfe.models.nrs.NotableEvent.ReportAReceiptNotableEvent
 import uk.gov.hmrc.emcstfe.models.nrs.reportOfReceipt.ReportOfReceiptNRSSubmission
 import uk.gov.hmrc.emcstfe.models.reportOfReceipt.SubmitReportOfReceiptModel
 import uk.gov.hmrc.emcstfe.models.response.ErrorResponse
@@ -46,8 +45,7 @@ class SubmitReportOfReceiptController @Inject()(cc: ControllerComponents,
   def submit(ern: String, arc: String): Action[JsValue] = authorisedUserSubmissionRequest(ern) { implicit request =>
     withJsonBody[SubmitReportOfReceiptModel] { submission =>
       if (isEnabled(EnableNRS)) {
-        val nrsSubmissionModel = ReportOfReceiptNRSSubmission.apply(submission, ern)
-        nrsBrokerService.submitPayload(nrsSubmissionModel, ern, ReportAReceiptNotableEvent).flatMap(_ => handleSubmission(submission))
+        nrsBrokerService.submitPayload(ReportOfReceiptNRSSubmission(submission, ern), ern).flatMap(_ => handleSubmission(submission))
       } else {
         handleSubmission(submission)
       }

--- a/app/uk/gov/hmrc/emcstfe/models/nrs/NRSSubmission.scala
+++ b/app/uk/gov/hmrc/emcstfe/models/nrs/NRSSubmission.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.emcstfe.models.nrs
+
+trait NRSSubmission {
+
+  val notableEvent: NotableEvent
+
+}

--- a/app/uk/gov/hmrc/emcstfe/models/nrs/alertReject/AlertRejectNRSSubmission.scala
+++ b/app/uk/gov/hmrc/emcstfe/models/nrs/alertReject/AlertRejectNRSSubmission.scala
@@ -19,6 +19,8 @@ package uk.gov.hmrc.emcstfe.models.nrs.alertReject
 import play.api.libs.json.{Json, Writes}
 import uk.gov.hmrc.emcstfe.models.alertOrRejection.{AlertOrRejectionReasonModel, SubmitAlertOrRejectionModel}
 import uk.gov.hmrc.emcstfe.models.common.{ExciseMovementModel, TraderModel}
+import uk.gov.hmrc.emcstfe.models.nrs.NotableEvent.AlertRejectNotableEvent
+import uk.gov.hmrc.emcstfe.models.nrs.{NRSSubmission, NotableEvent}
 
 import java.time.LocalDate
 
@@ -32,7 +34,9 @@ case class AlertRejectNRSSubmission(
                                   dateOfAlertOrRejection: LocalDate,
                                   isRejected: Boolean,
                                   alertOrRejectionReasons: Option[Seq[AlertOrRejectionReasonModel]]
-                                )
+                                ) extends NRSSubmission {
+  override val notableEvent: NotableEvent = AlertRejectNotableEvent
+}
 
 object AlertRejectNRSSubmission {
 

--- a/app/uk/gov/hmrc/emcstfe/models/nrs/cancelMovement/CancelMovementNRSSubmission.scala
+++ b/app/uk/gov/hmrc/emcstfe/models/nrs/cancelMovement/CancelMovementNRSSubmission.scala
@@ -19,6 +19,8 @@ package uk.gov.hmrc.emcstfe.models.nrs.cancelMovement
 import play.api.libs.json.{Json, Writes}
 import uk.gov.hmrc.emcstfe.models.cancellationOfMovement.{CancellationReasonType, SubmitCancellationOfMovementModel}
 import uk.gov.hmrc.emcstfe.models.common.{DestinationType, TraderModel}
+import uk.gov.hmrc.emcstfe.models.nrs.NotableEvent.CancelMovementNotableEvent
+import uk.gov.hmrc.emcstfe.models.nrs.{NRSSubmission, NotableEvent}
 
 //Based from the FE audit model
 case class CancelMovementNRSSubmission(
@@ -30,7 +32,9 @@ case class CancelMovementNRSSubmission(
                                         memberStateCode: Option[String],
                                         cancelReason: CancellationReasonType,
                                         additionalInformation: Option[String]
-                                      )
+                                      ) extends NRSSubmission {
+  override val notableEvent: NotableEvent = CancelMovementNotableEvent
+}
 
 object CancelMovementNRSSubmission {
 

--- a/app/uk/gov/hmrc/emcstfe/models/nrs/createMovement/CreateMovementNRSSubmission.scala
+++ b/app/uk/gov/hmrc/emcstfe/models/nrs/createMovement/CreateMovementNRSSubmission.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.emcstfe.models.nrs.createMovement
+
+import play.api.libs.json.{JsValue, Json, Writes}
+import uk.gov.hmrc.emcstfe.models.createMovement.SubmitCreateMovementModel
+import uk.gov.hmrc.emcstfe.models.nrs.NotableEvent.CreateMovementNotableEvent
+import uk.gov.hmrc.emcstfe.models.nrs.{NRSSubmission, NotableEvent}
+
+case class CreateMovementNRSSubmission(ern: String,
+                                       submissionRequest: SubmitCreateMovementModel) extends NRSSubmission {
+  val json: JsValue =
+    Json.toJsObject(submissionRequest).deepMerge(Json.obj("exciseRegistrationNumber" -> ern))
+
+  override val notableEvent: NotableEvent = CreateMovementNotableEvent
+}
+
+object CreateMovementNRSSubmission {
+  implicit val writes: Writes[CreateMovementNRSSubmission] = Writes(_.json)
+}

--- a/app/uk/gov/hmrc/emcstfe/models/nrs/explainDelay/ExplainDelayNRSSubmission.scala
+++ b/app/uk/gov/hmrc/emcstfe/models/nrs/explainDelay/ExplainDelayNRSSubmission.scala
@@ -19,13 +19,17 @@ package uk.gov.hmrc.emcstfe.models.nrs.explainDelay
 import play.api.libs.json.{Json, Writes}
 import uk.gov.hmrc.emcstfe.models.common.SubmitterType
 import uk.gov.hmrc.emcstfe.models.explainDelay.{DelayReasonType, DelayType, SubmitExplainDelayModel}
+import uk.gov.hmrc.emcstfe.models.nrs.NotableEvent.ExplainDelayNotableEvent
+import uk.gov.hmrc.emcstfe.models.nrs.{NRSSubmission, NotableEvent}
 
 case class ExplainDelayNRSSubmission(arc: String,
                                      sequenceNumber: Int,
                                      submitterType: SubmitterType,
                                      delayType: DelayType,
                                      delayReasonType: DelayReasonType,
-                                     additionalInformation: Option[String])
+                                     additionalInformation: Option[String]) extends NRSSubmission {
+  override val notableEvent: NotableEvent = ExplainDelayNotableEvent
+}
 
 object ExplainDelayNRSSubmission {
   def apply(submission: SubmitExplainDelayModel): ExplainDelayNRSSubmission = ExplainDelayNRSSubmission(

--- a/app/uk/gov/hmrc/emcstfe/models/nrs/explainShortageExcess/ExplainShortageExcessNRSSubmission.scala
+++ b/app/uk/gov/hmrc/emcstfe/models/nrs/explainShortageExcess/ExplainShortageExcessNRSSubmission.scala
@@ -19,6 +19,8 @@ package uk.gov.hmrc.emcstfe.models.nrs.explainShortageExcess
 import play.api.libs.json.{Json, Writes}
 import uk.gov.hmrc.emcstfe.models.common.{SubmitterType, TraderModel}
 import uk.gov.hmrc.emcstfe.models.explainShortageExcess.{BodyAnalysisModel, SubmitExplainShortageExcessModel}
+import uk.gov.hmrc.emcstfe.models.nrs.NotableEvent.ExplainShortageOrExcessNotableEvent
+import uk.gov.hmrc.emcstfe.models.nrs.{NRSSubmission, NotableEvent}
 
 case class ExplainShortageExcessNRSSubmission(
                                                ern: String,
@@ -30,7 +32,9 @@ case class ExplainShortageExcessNRSSubmission(
                                                individualItems: Option[Seq[BodyAnalysisModel]],
                                                dateOfAnalysis: Option[String],
                                                globalExplanation: Option[String]
-                                             )
+                                             ) extends NRSSubmission {
+  override val notableEvent: NotableEvent = ExplainShortageOrExcessNotableEvent
+}
 
 object ExplainShortageExcessNRSSubmission {
 

--- a/app/uk/gov/hmrc/emcstfe/models/nrs/reportOfReceipt/ReportOfReceiptNRSSubmission.scala
+++ b/app/uk/gov/hmrc/emcstfe/models/nrs/reportOfReceipt/ReportOfReceiptNRSSubmission.scala
@@ -18,6 +18,8 @@ package uk.gov.hmrc.emcstfe.models.nrs.reportOfReceipt
 
 import play.api.libs.json.{Json, Writes}
 import uk.gov.hmrc.emcstfe.models.common.{AcceptMovement, DestinationType, TraderModel}
+import uk.gov.hmrc.emcstfe.models.nrs.NRSSubmission
+import uk.gov.hmrc.emcstfe.models.nrs.NotableEvent.ReportAReceiptNotableEvent
 import uk.gov.hmrc.emcstfe.models.reportOfReceipt.{ReceiptedItemsModel, SubmitReportOfReceiptModel}
 
 import java.time.LocalDate
@@ -35,7 +37,9 @@ case class ReportOfReceiptNRSSubmission(
                                          acceptMovement: AcceptMovement,
                                          individualItems: Seq[ReceiptedItemsModel],
                                          otherInformation: Option[String]
-                                       )
+                                       ) extends NRSSubmission {
+  override val notableEvent = ReportAReceiptNotableEvent
+}
 
 object ReportOfReceiptNRSSubmission {
 

--- a/it/uk/gov/hmrc/emcstfe/controllers/SubmitCancellationOfMovementControllerIntegrationSpec.scala
+++ b/it/uk/gov/hmrc/emcstfe/controllers/SubmitCancellationOfMovementControllerIntegrationSpec.scala
@@ -25,6 +25,7 @@ import play.api.libs.ws.{WSRequest, WSResponse}
 import uk.gov.hmrc.emcstfe.config.AppConfig
 import uk.gov.hmrc.emcstfe.featureswitch.core.config.{EnableNRS, FeatureSwitching, SendToEIS}
 import uk.gov.hmrc.emcstfe.fixtures.{NRSBrokerFixtures, SubmitCancellationOfMovementFixtures}
+import uk.gov.hmrc.emcstfe.models.nrs.cancelMovement.CancelMovementNRSSubmission
 import uk.gov.hmrc.emcstfe.models.response.ChRISSuccessResponse
 import uk.gov.hmrc.emcstfe.models.response.ErrorResponse._
 import uk.gov.hmrc.emcstfe.stubs.{AuthStub, DownstreamStub}
@@ -183,9 +184,9 @@ class SubmitCancellationOfMovementControllerIntegrationSpec extends IntegrationB
           If userSubmissionTimestamp or headerData was missing in the actual payload then the test would fail.
          */
         val nrsRequestBody: JsObject = {
-          Json.toJson(cancelMovementNRSPayload.copy(
-            metadata = cancelMovementNRSPayload.metadata.copy(userAuthToken = "auth1234"))
-          ).as[JsObject].deepMerge(Json.obj("metadata" -> Json.obj("userSubmissionTimestamp" -> f"$${json-unit.any-string}", "headerData" -> f"$${json-unit.ignore}")))
+          Json.toJson(createNRSPayload(CancelMovementNRSSubmission(maxSubmitCancellationOfMovementModel, testErn)))
+            .as[JsObject]
+            .deepMerge(Json.obj("metadata" -> Json.obj("userSubmissionTimestamp" -> f"$${json-unit.any-string}", "headerData" -> f"$${json-unit.ignore}")))
         }
 
         override def setupStubs(): StubMapping = {
@@ -193,7 +194,7 @@ class SubmitCancellationOfMovementControllerIntegrationSpec extends IntegrationB
           enable(EnableNRS)
           AuthStub.authorised(withIdentityData = true)
           DownstreamStub.onSuccess(DownstreamStub.POST, downstreamEisUri, Status.OK, eisSuccessJson())
-          DownstreamStub.onSuccessWithRequestBodyAndHeaders(DownstreamStub.PUT, downstreamNRSBrokerUri, status = Status.ACCEPTED, requestBody = Some(Json.stringify(nrsRequestBody)), responseBody = nrsBrokerResponseJson, headers = Map("Authorization" -> "auth1234"))
+          DownstreamStub.onSuccessWithRequestBodyAndHeaders(DownstreamStub.PUT, downstreamNRSBrokerUri, status = Status.ACCEPTED, requestBody = Some(Json.stringify(nrsRequestBody)), responseBody = nrsBrokerResponseJson, headers = Map("Authorization" -> testAuthToken))
         }
 
         val response: WSResponse = await(request().post(maxSubmitCancellationOfMovementModelJson))

--- a/it/uk/gov/hmrc/emcstfe/controllers/SubmitCreateMovementIntegrationSpec.scala
+++ b/it/uk/gov/hmrc/emcstfe/controllers/SubmitCreateMovementIntegrationSpec.scala
@@ -16,14 +16,16 @@
 
 package uk.gov.hmrc.emcstfe.controllers
 
+import com.github.tomakehurst.wiremock.client.WireMock.{putRequestedFor, urlEqualTo, verify}
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
 import com.lucidchart.open.xtract.EmptyError
 import play.api.http.Status
-import play.api.libs.json.{JsValue, Json}
+import play.api.libs.json.{JsObject, JsValue, Json}
 import play.api.libs.ws.{WSRequest, WSResponse}
 import uk.gov.hmrc.emcstfe.config.AppConfig
-import uk.gov.hmrc.emcstfe.featureswitch.core.config.{DefaultDraftMovementCorrelationId, FeatureSwitching, SendToEIS}
-import uk.gov.hmrc.emcstfe.fixtures.CreateMovementFixtures
+import uk.gov.hmrc.emcstfe.featureswitch.core.config.{DefaultDraftMovementCorrelationId, EnableNRS, FeatureSwitching, SendToEIS}
+import uk.gov.hmrc.emcstfe.fixtures.{CreateMovementFixtures, NRSBrokerFixtures}
+import uk.gov.hmrc.emcstfe.models.nrs.createMovement.CreateMovementNRSSubmission
 import uk.gov.hmrc.emcstfe.models.response.ChRISSuccessResponse
 import uk.gov.hmrc.emcstfe.models.response.ErrorResponse._
 import uk.gov.hmrc.emcstfe.stubs.{AuthStub, DownstreamStub}
@@ -31,7 +33,10 @@ import uk.gov.hmrc.emcstfe.support.IntegrationBaseSpec
 
 import scala.xml.XML
 
-class SubmitCreateMovementIntegrationSpec extends IntegrationBaseSpec with CreateMovementFixtures with FeatureSwitching {
+class SubmitCreateMovementIntegrationSpec extends IntegrationBaseSpec
+  with CreateMovementFixtures
+  with NRSBrokerFixtures
+  with FeatureSwitching {
 
   override val config: AppConfig = app.injector.instanceOf[AppConfig]
 
@@ -44,6 +49,8 @@ class SubmitCreateMovementIntegrationSpec extends IntegrationBaseSpec with Creat
 
     def downstreamEisUri: String = s"/emcs/digital-submit-new-message/v1"
 
+    def downstreamNRSBrokerUri: String = s"/emcs-tfe-nrs-message-broker/trader/$testErn/nrs/submission"
+
     def request(): WSRequest = {
       setupStubs()
       buildRequest(uri, "Content-Type" -> "application/json")
@@ -55,6 +62,7 @@ class SubmitCreateMovementIntegrationSpec extends IntegrationBaseSpec with Creat
     super.beforeEach()
     enable(DefaultDraftMovementCorrelationId)
     disable(SendToEIS)
+    disable(EnableNRS)
   }
 
   override def afterEach(): Unit = {
@@ -176,6 +184,39 @@ class SubmitCreateMovementIntegrationSpec extends IntegrationBaseSpec with Creat
           response.json shouldBe Json.toJson(EISInternalServerError("bad things"))
         }
       }
+    }
+  }
+
+  "when submitting payloads to NRS (downstream submission agnostic)" must {
+
+    "return a success" in new Test {
+
+      /*
+        This uses JsonUnit (a Wiremock-provided library) to ignore some unmatchable body elements.
+        In this case userSubmissionTimestamp is naturally impossible to match accurately.
+        Header data is made up as part of the request processing, so the tests can't accurately replicate this.
+        If userSubmissionTimestamp or headerData was missing in the actual payload then the test would fail.
+       */
+      val nrsRequestBody: JsObject = {
+        Json.toJson(createNRSPayload(CreateMovementNRSSubmission(testErn, CreateMovementFixtures.createMovementModelMax)))
+          .as[JsObject]
+          .deepMerge(Json.obj("metadata" -> Json.obj("userSubmissionTimestamp" -> f"$${json-unit.any-string}", "headerData" -> f"$${json-unit.ignore}")))
+      }
+
+      override def setupStubs(): StubMapping = {
+        enable(SendToEIS)
+        enable(EnableNRS)
+        AuthStub.authorised(withIdentityData = true)
+        DownstreamStub.onSuccess(DownstreamStub.POST, downstreamEisUri, Status.OK, eisSuccessJson())
+        DownstreamStub.onSuccessWithRequestBodyAndHeaders(DownstreamStub.PUT, downstreamNRSBrokerUri, status = Status.ACCEPTED, requestBody = Some(Json.stringify(nrsRequestBody)), responseBody = nrsBrokerResponseJson, headers = Map("Authorization" -> testAuthToken))
+      }
+
+      val response: WSResponse = await(request().post(CreateMovementFixtures.createMovementJsonMax))
+      response.status shouldBe Status.OK
+      response.header("Content-Type") shouldBe Some("application/json")
+      response.json shouldBe eisSuccessJson(withSubmittedDraftId = true, Some("PORTAL123"))
+      verify(1, putRequestedFor(urlEqualTo(s"/emcs-tfe-nrs-message-broker/trader/$testErn/nrs/submission")))
+      wireMockServer.findAllUnmatchedRequests.size() shouldBe 0
     }
   }
 }

--- a/it/uk/gov/hmrc/emcstfe/controllers/SubmitExplainDelayIntegrationSpec.scala
+++ b/it/uk/gov/hmrc/emcstfe/controllers/SubmitExplainDelayIntegrationSpec.scala
@@ -25,6 +25,7 @@ import play.api.libs.ws.{WSRequest, WSResponse}
 import uk.gov.hmrc.emcstfe.config.AppConfig
 import uk.gov.hmrc.emcstfe.featureswitch.core.config.{EnableNRS, FeatureSwitching, SendToEIS}
 import uk.gov.hmrc.emcstfe.fixtures.{NRSBrokerFixtures, SubmitExplainDelayFixtures}
+import uk.gov.hmrc.emcstfe.models.nrs.explainDelay.ExplainDelayNRSSubmission
 import uk.gov.hmrc.emcstfe.models.response.ChRISSuccessResponse
 import uk.gov.hmrc.emcstfe.models.response.ErrorResponse._
 import uk.gov.hmrc.emcstfe.stubs.{AuthStub, DownstreamStub}
@@ -178,9 +179,9 @@ class SubmitExplainDelayIntegrationSpec
           If userSubmissionTimestamp or headerData was missing in the actual payload then the test would fail.
          */
         val nrsRequestBody: JsObject = {
-          Json.toJson(explainDelayNRSPayload.copy(
-            metadata = explainDelayNRSPayload.metadata.copy(userAuthToken = "auth1234"))
-          ).as[JsObject].deepMerge(Json.obj("metadata" -> Json.obj("userSubmissionTimestamp" -> f"$${json-unit.any-string}", "headerData" -> f"$${json-unit.ignore}")))
+          Json.toJson(createNRSPayload(ExplainDelayNRSSubmission(maxSubmitExplainDelayModel)))
+            .as[JsObject]
+            .deepMerge(Json.obj("metadata" -> Json.obj("userSubmissionTimestamp" -> f"$${json-unit.any-string}", "headerData" -> f"$${json-unit.ignore}")))
         }
 
         override def setupStubs(): StubMapping = {
@@ -188,7 +189,7 @@ class SubmitExplainDelayIntegrationSpec
           enable(EnableNRS)
           AuthStub.authorised(withIdentityData = true)
           DownstreamStub.onSuccess(DownstreamStub.POST, downstreamEisUri, Status.OK, eisSuccessJson())
-          DownstreamStub.onSuccessWithRequestBodyAndHeaders(DownstreamStub.PUT, downstreamNRSBrokerUri, status = Status.ACCEPTED, requestBody = Some(Json.stringify(nrsRequestBody)), responseBody = nrsBrokerResponseJson, headers = Map("Authorization" -> "auth1234"))
+          DownstreamStub.onSuccessWithRequestBodyAndHeaders(DownstreamStub.PUT, downstreamNRSBrokerUri, status = Status.ACCEPTED, requestBody = Some(Json.stringify(nrsRequestBody)), responseBody = nrsBrokerResponseJson, headers = Map("Authorization" -> testAuthToken))
         }
 
         val response: WSResponse = await(request().post(Json.toJson(maxSubmitExplainDelayModel)))

--- a/it/uk/gov/hmrc/emcstfe/controllers/SubmitReportOfReceiptIntegrationSpec.scala
+++ b/it/uk/gov/hmrc/emcstfe/controllers/SubmitReportOfReceiptIntegrationSpec.scala
@@ -25,6 +25,7 @@ import play.api.libs.ws.{WSRequest, WSResponse}
 import uk.gov.hmrc.emcstfe.config.AppConfig
 import uk.gov.hmrc.emcstfe.featureswitch.core.config.{EnableNRS, FeatureSwitching, SendToEIS}
 import uk.gov.hmrc.emcstfe.fixtures.{NRSBrokerFixtures, SubmitReportOfReceiptFixtures}
+import uk.gov.hmrc.emcstfe.models.nrs.reportOfReceipt.ReportOfReceiptNRSSubmission
 import uk.gov.hmrc.emcstfe.models.response.ChRISSuccessResponse
 import uk.gov.hmrc.emcstfe.models.response.ErrorResponse._
 import uk.gov.hmrc.emcstfe.stubs.{AuthStub, DownstreamStub}
@@ -188,9 +189,9 @@ class SubmitReportOfReceiptIntegrationSpec extends IntegrationBaseSpec
           If userSubmissionTimestamp or headerData was missing in the actual payload then the test would fail.
          */
         val nrsRequestBody: JsObject = {
-          Json.toJson(reportOfReceiptNRSPayload.copy(
-            metadata = reportOfReceiptNRSPayload.metadata.copy(userAuthToken = "auth1234"))
-          ).as[JsObject].deepMerge(Json.obj("metadata" -> Json.obj("userSubmissionTimestamp" -> f"$${json-unit.any-string}", "headerData" -> f"$${json-unit.ignore}")))
+          Json.toJson(createNRSPayload(ReportOfReceiptNRSSubmission(minSubmitReportOfReceiptModel, testErn)))
+            .as[JsObject]
+            .deepMerge(Json.obj("metadata" -> Json.obj("userSubmissionTimestamp" -> f"$${json-unit.any-string}", "headerData" -> f"$${json-unit.ignore}")))
         }
 
         override def setupStubs(): StubMapping = {
@@ -198,7 +199,7 @@ class SubmitReportOfReceiptIntegrationSpec extends IntegrationBaseSpec
           enable(EnableNRS)
           AuthStub.authorised(withIdentityData = true)
           DownstreamStub.onSuccess(DownstreamStub.POST, downstreamEisUri, Status.OK, eisSuccessJson())
-          DownstreamStub.onSuccessWithRequestBodyAndHeaders(DownstreamStub.PUT, downstreamNRSBrokerUri, status = Status.ACCEPTED, requestBody = Some(Json.stringify(nrsRequestBody)), responseBody = nrsBrokerResponseJson, headers = Map("Authorization" -> "auth1234"))
+          DownstreamStub.onSuccessWithRequestBodyAndHeaders(DownstreamStub.PUT, downstreamNRSBrokerUri, status = Status.ACCEPTED, requestBody = Some(Json.stringify(nrsRequestBody)), responseBody = nrsBrokerResponseJson, headers = Map("Authorization" -> testAuthToken))
         }
 
         val response: WSResponse = await(request().post(Json.toJson(minSubmitReportOfReceiptModel)))

--- a/it/uk/gov/hmrc/emcstfe/support/IntegrationBaseSpec.scala
+++ b/it/uk/gov/hmrc/emcstfe/support/IntegrationBaseSpec.scala
@@ -77,7 +77,7 @@ trait IntegrationBaseSpec
 
   def buildRequest(path: String, extraHeaders: (String, String)*): WSRequest = client
     .url(s"http://localhost:$port/emcs-tfe$path")
-    .withHttpHeaders(Seq(HeaderNames.AUTHORIZATION -> "auth1234") ++ extraHeaders: _*)
+    .withHttpHeaders(Seq(HeaderNames.AUTHORIZATION -> testAuthToken) ++ extraHeaders: _*)
     .withFollowRedirects(false)
 
   def document(response: WSResponse): JsValue = Json.parse(response.body)

--- a/test/uk/gov/hmrc/emcstfe/controllers/SubmitAlertOrRejectionControllerSpec.scala
+++ b/test/uk/gov/hmrc/emcstfe/controllers/SubmitAlertOrRejectionControllerSpec.scala
@@ -27,7 +27,6 @@ import uk.gov.hmrc.emcstfe.featureswitch.core.config.{EnableNRS, SendToEIS}
 import uk.gov.hmrc.emcstfe.fixtures.{NRSBrokerFixtures, SubmitAlertOrRejectionFixtures}
 import uk.gov.hmrc.emcstfe.mocks.config.MockAppConfig
 import uk.gov.hmrc.emcstfe.mocks.services.{MockNRSBrokerService, MockSubmitAlertOrRejectionService}
-import uk.gov.hmrc.emcstfe.models.nrs.NotableEvent.AlertRejectNotableEvent
 import uk.gov.hmrc.emcstfe.models.response.ErrorResponse.UnexpectedDownstreamResponseError
 import uk.gov.hmrc.emcstfe.support.TestBaseSpec
 
@@ -47,7 +46,7 @@ class SubmitAlertOrRejectionControllerSpec extends TestBaseSpec
       MockedAppConfig.getFeatureSwitchValue(EnableNRS).returns(isNRSEnabled)
 
       if (isNRSEnabled) {
-        MockNRSBrokerService.submitPayload(alertRejectNRSSubmission, testErn, AlertRejectNotableEvent).returns(Future.successful(Right(nrsBrokerResponseModel)))
+        MockNRSBrokerService.submitPayload(alertRejectNRSSubmission, testErn).returns(Future.successful(Right(nrsBrokerResponseModel)))
       }
     }
 

--- a/test/uk/gov/hmrc/emcstfe/controllers/SubmitCancellationOfMovementControllerSpec.scala
+++ b/test/uk/gov/hmrc/emcstfe/controllers/SubmitCancellationOfMovementControllerSpec.scala
@@ -26,7 +26,6 @@ import uk.gov.hmrc.emcstfe.featureswitch.core.config.{EnableNRS, SendToEIS}
 import uk.gov.hmrc.emcstfe.fixtures.{NRSBrokerFixtures, SubmitCancellationOfMovementFixtures}
 import uk.gov.hmrc.emcstfe.mocks.config.MockAppConfig
 import uk.gov.hmrc.emcstfe.mocks.services.{MockNRSBrokerService, MockSubmitCancellationOfMovementService}
-import uk.gov.hmrc.emcstfe.models.nrs.NotableEvent.CancelMovementNotableEvent
 import uk.gov.hmrc.emcstfe.models.response.ErrorResponse.UnexpectedDownstreamResponseError
 import uk.gov.hmrc.emcstfe.support.TestBaseSpec
 
@@ -46,7 +45,7 @@ class SubmitCancellationOfMovementControllerSpec extends TestBaseSpec
       MockedAppConfig.getFeatureSwitchValue(EnableNRS).returns(isNRSEnabled)
 
       if (isNRSEnabled) {
-        MockNRSBrokerService.submitPayload(cancelMovementNRSSubmission, testErn, CancelMovementNotableEvent).returns(Future.successful(Right(nrsBrokerResponseModel)))
+        MockNRSBrokerService.submitPayload(cancelMovementNRSSubmission, testErn).returns(Future.successful(Right(nrsBrokerResponseModel)))
       }
     }
 

--- a/test/uk/gov/hmrc/emcstfe/controllers/SubmitExplainDelayControllerSpec.scala
+++ b/test/uk/gov/hmrc/emcstfe/controllers/SubmitExplainDelayControllerSpec.scala
@@ -26,7 +26,6 @@ import uk.gov.hmrc.emcstfe.featureswitch.core.config.{EnableNRS, SendToEIS}
 import uk.gov.hmrc.emcstfe.fixtures.{NRSBrokerFixtures, SubmitExplainDelayFixtures}
 import uk.gov.hmrc.emcstfe.mocks.config.MockAppConfig
 import uk.gov.hmrc.emcstfe.mocks.services.{MockNRSBrokerService, MockSubmitExplainDelayService}
-import uk.gov.hmrc.emcstfe.models.nrs.NotableEvent.ExplainDelayNotableEvent
 import uk.gov.hmrc.emcstfe.models.response.ErrorResponse.UnexpectedDownstreamResponseError
 import uk.gov.hmrc.emcstfe.support.TestBaseSpec
 
@@ -46,7 +45,7 @@ class SubmitExplainDelayControllerSpec
       MockedAppConfig.getFeatureSwitchValue(EnableNRS).returns(isNRSEnabled)
 
       if (isNRSEnabled) {
-        MockNRSBrokerService.submitPayload(explainDelayNRSSubmission, testErn, ExplainDelayNotableEvent).returns(Future.successful(Right(nrsBrokerResponseModel)))
+        MockNRSBrokerService.submitPayload(explainDelayNRSSubmission, testErn).returns(Future.successful(Right(nrsBrokerResponseModel)))
       }
     }
 

--- a/test/uk/gov/hmrc/emcstfe/controllers/SubmitExplainShortageExcessControllerSpec.scala
+++ b/test/uk/gov/hmrc/emcstfe/controllers/SubmitExplainShortageExcessControllerSpec.scala
@@ -27,7 +27,6 @@ import uk.gov.hmrc.emcstfe.fixtures.{NRSBrokerFixtures, SubmitExplainShortageExc
 import uk.gov.hmrc.emcstfe.mocks.config.MockAppConfig
 import uk.gov.hmrc.emcstfe.mocks.services.{MockNRSBrokerService, MockSubmitExplainShortageExcessService}
 import uk.gov.hmrc.emcstfe.models.common.SubmitterType.Consignor
-import uk.gov.hmrc.emcstfe.models.nrs.NotableEvent.ExplainShortageOrExcessNotableEvent
 import uk.gov.hmrc.emcstfe.models.response.ErrorResponse.UnexpectedDownstreamResponseError
 import uk.gov.hmrc.emcstfe.support.TestBaseSpec
 
@@ -49,7 +48,7 @@ class SubmitExplainShortageExcessControllerSpec extends TestBaseSpec
       MockedAppConfig.getFeatureSwitchValue(EnableNRS).returns(isNRSEnabled)
 
       if (isNRSEnabled) {
-        MockNRSBrokerService.submitPayload(explainShortageExcessNRSSubmission(Consignor, testErn), testErn, ExplainShortageOrExcessNotableEvent).returns(Future.successful(Right(nrsBrokerResponseModel)))
+        MockNRSBrokerService.submitPayload(explainShortageExcessNRSSubmission(Consignor, testErn), testErn).returns(Future.successful(Right(nrsBrokerResponseModel)))
       }
     }
 

--- a/test/uk/gov/hmrc/emcstfe/controllers/SubmitReportOfReceiptControllerSpec.scala
+++ b/test/uk/gov/hmrc/emcstfe/controllers/SubmitReportOfReceiptControllerSpec.scala
@@ -26,7 +26,6 @@ import uk.gov.hmrc.emcstfe.featureswitch.core.config.{EnableNRS, SendToEIS}
 import uk.gov.hmrc.emcstfe.fixtures.{NRSBrokerFixtures, SubmitReportOfReceiptFixtures}
 import uk.gov.hmrc.emcstfe.mocks.config.MockAppConfig
 import uk.gov.hmrc.emcstfe.mocks.services.{MockNRSBrokerService, MockSubmitReportOfReceiptService}
-import uk.gov.hmrc.emcstfe.models.nrs.NotableEvent.ReportAReceiptNotableEvent
 import uk.gov.hmrc.emcstfe.models.response.ErrorResponse.{EISServiceUnavailableError, UnexpectedDownstreamResponseError}
 import uk.gov.hmrc.emcstfe.support.TestBaseSpec
 
@@ -60,7 +59,7 @@ class SubmitReportOfReceiptControllerSpec extends TestBaseSpec
               MockedAppConfig.getFeatureSwitchValue(SendToEIS).returns(false)
               MockedAppConfig.getFeatureSwitchValue(EnableNRS).returns(true)
 
-              MockNRSBrokerService.submitPayload(reportOfReceiptNRSSubmission, testErn, ReportAReceiptNotableEvent).returns(Future.successful(Right(nrsBrokerResponseModel)))
+              MockNRSBrokerService.submitPayload(reportOfReceiptNRSSubmission, testErn).returns(Future.successful(Right(nrsBrokerResponseModel)))
               MockService.submit(maxSubmitReportOfReceiptModel).returns(Future.successful(Right(chrisSuccessResponse)))
 
               val result = controller.submit(testErn, testArc)(fakeRequest)
@@ -77,7 +76,7 @@ class SubmitReportOfReceiptControllerSpec extends TestBaseSpec
               MockedAppConfig.getFeatureSwitchValue(SendToEIS).returns(false)
               MockedAppConfig.getFeatureSwitchValue(EnableNRS).returns(true)
 
-              MockNRSBrokerService.submitPayload(reportOfReceiptNRSSubmission, testErn, ReportAReceiptNotableEvent).returns(Future.successful(Right(nrsBrokerResponseModel)))
+              MockNRSBrokerService.submitPayload(reportOfReceiptNRSSubmission, testErn).returns(Future.successful(Right(nrsBrokerResponseModel)))
               MockService.submit(maxSubmitReportOfReceiptModel).returns(Future.successful(Left(UnexpectedDownstreamResponseError)))
 
               val result = controller.submit(testErn, testArc)(fakeRequest)
@@ -97,7 +96,7 @@ class SubmitReportOfReceiptControllerSpec extends TestBaseSpec
               MockedAppConfig.getFeatureSwitchValue(SendToEIS).returns(true)
               MockedAppConfig.getFeatureSwitchValue(EnableNRS).returns(true)
 
-              MockNRSBrokerService.submitPayload(reportOfReceiptNRSSubmission, testErn, ReportAReceiptNotableEvent).returns(Future.successful(Right(nrsBrokerResponseModel)))
+              MockNRSBrokerService.submitPayload(reportOfReceiptNRSSubmission, testErn).returns(Future.successful(Right(nrsBrokerResponseModel)))
               MockService.submitViaEIS(maxSubmitReportOfReceiptModel).returns(Future.successful(Right(eisSuccessResponse)))
 
               val result = controller.submit(testErn, testArc)(fakeRequest)
@@ -114,7 +113,7 @@ class SubmitReportOfReceiptControllerSpec extends TestBaseSpec
               MockedAppConfig.getFeatureSwitchValue(SendToEIS).returns(true)
               MockedAppConfig.getFeatureSwitchValue(EnableNRS).returns(true)
 
-              MockNRSBrokerService.submitPayload(reportOfReceiptNRSSubmission, testErn, ReportAReceiptNotableEvent).returns(Future.successful(Right(nrsBrokerResponseModel)))
+              MockNRSBrokerService.submitPayload(reportOfReceiptNRSSubmission, testErn).returns(Future.successful(Right(nrsBrokerResponseModel)))
               MockService.submitViaEIS(maxSubmitReportOfReceiptModel).returns(Future.successful(Left(EISServiceUnavailableError("SERVICE_UNAVAILABLE"))))
 
               val result = controller.submit(testErn, testArc)(fakeRequest)

--- a/test/uk/gov/hmrc/emcstfe/fixtures/BaseFixtures.scala
+++ b/test/uk/gov/hmrc/emcstfe/fixtures/BaseFixtures.scala
@@ -21,6 +21,7 @@ import scala.xml.{Node, NodeSeq, PCData}
 
 trait BaseFixtures {
 
+  val testAuthToken = "Bearer token"
   val testErn = "GBWK000001234"
   val testArc: String = "23GB00000000000376967"
   val testLrn: String = "LRN"

--- a/test/uk/gov/hmrc/emcstfe/mocks/services/MockNRSBrokerService.scala
+++ b/test/uk/gov/hmrc/emcstfe/mocks/services/MockNRSBrokerService.scala
@@ -16,11 +16,11 @@
 
 package uk.gov.hmrc.emcstfe.mocks.services
 
-import org.scalamock.handlers.CallHandler7
+import org.scalamock.handlers.CallHandler6
 import org.scalamock.scalatest.MockFactory
 import play.api.libs.json.Writes
 import uk.gov.hmrc.emcstfe.models.auth.UserRequest
-import uk.gov.hmrc.emcstfe.models.nrs.NotableEvent
+import uk.gov.hmrc.emcstfe.models.nrs.NRSSubmission
 import uk.gov.hmrc.emcstfe.models.response.ErrorResponse
 import uk.gov.hmrc.emcstfe.models.response.nrsBroker.NRSBrokerInsertPayloadResponse
 import uk.gov.hmrc.emcstfe.services.nrs.NRSBrokerService
@@ -34,9 +34,9 @@ trait MockNRSBrokerService extends MockFactory {
 
   object MockNRSBrokerService {
 
-    def submitPayload[A](submission: A, ern: String, notableEvent: NotableEvent): CallHandler7[A, String, NotableEvent, HeaderCarrier, ExecutionContext, UserRequest[_], Writes[A], Future[Either[ErrorResponse, NRSBrokerInsertPayloadResponse]]] = {
-      (mockNRSBrokerService.submitPayload(_: A, _: String, _: NotableEvent)(_: HeaderCarrier, _: ExecutionContext, _: UserRequest[_], _: Writes[A]))
-        .expects(submission, ern, notableEvent, *, *, *, *)
+    def submitPayload[A <: NRSSubmission](submission: A, ern: String): CallHandler6[A, String, HeaderCarrier, ExecutionContext, UserRequest[_], Writes[A], Future[Either[ErrorResponse, NRSBrokerInsertPayloadResponse]]] = {
+      (mockNRSBrokerService.submitPayload(_: A, _: String)(_: HeaderCarrier, _: ExecutionContext, _: UserRequest[_], _: Writes[A]))
+        .expects(submission, ern, *, *, *, *)
     }
   }
 

--- a/test/uk/gov/hmrc/emcstfe/models/nrs/NRSPayloadSpec.scala
+++ b/test/uk/gov/hmrc/emcstfe/models/nrs/NRSPayloadSpec.scala
@@ -30,7 +30,7 @@ class NRSPayloadSpec extends TestBaseSpec with NRSBrokerFixtures {
 
     "generate the correct payload by encoding, hashing the payload and applying the correct attributes" in {
 
-      val result = NRSPayload.apply(testPlainTextPayload, CreateMovementNotableEvent, identityDataModel, testErn, Instant.ofEpochMilli(1L))(hc.copy(authorization = Some(Authorization("Bearer token"))), implicitly)
+      val result = NRSPayload.apply(testPlainTextPayload, CreateMovementNotableEvent, identityDataModel, testErn, Instant.ofEpochMilli(1L))(hc.copy(authorization = Some(Authorization(testAuthToken))), implicitly)
 
       result shouldBe nrsPayloadModel.copy(metadata = nrsPayloadModel.metadata.copy(headerData = Json.obj("Host" -> "localhost")))
     }

--- a/test/uk/gov/hmrc/emcstfe/models/nrs/alertReject/AlertRejectNRSSubmissionSpec.scala
+++ b/test/uk/gov/hmrc/emcstfe/models/nrs/alertReject/AlertRejectNRSSubmissionSpec.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.emcstfe.models.nrs.alertReject
 
 import uk.gov.hmrc.emcstfe.fixtures.SubmitAlertOrRejectionFixtures
 import uk.gov.hmrc.emcstfe.models.alertOrRejection.SubmitAlertOrRejectionModel
+import uk.gov.hmrc.emcstfe.models.nrs.NotableEvent.AlertRejectNotableEvent
 import uk.gov.hmrc.emcstfe.support.TestBaseSpec
 
 class AlertRejectNRSSubmissionSpec extends TestBaseSpec with SubmitAlertOrRejectionFixtures {
@@ -25,8 +26,11 @@ class AlertRejectNRSSubmissionSpec extends TestBaseSpec with SubmitAlertOrReject
   ".apply" should {
 
     s"generate the correct model from the $SubmitAlertOrRejectionModel" in {
+      AlertRejectNRSSubmission(maxSubmitAlertOrRejectionModel) shouldBe alertRejectNRSSubmission
+    }
 
-      AlertRejectNRSSubmission.apply(maxSubmitAlertOrRejectionModel) shouldBe alertRejectNRSSubmission
+    "have the correct notableEvent" in {
+      AlertRejectNRSSubmission(maxSubmitAlertOrRejectionModel).notableEvent shouldBe AlertRejectNotableEvent
     }
   }
 }

--- a/test/uk/gov/hmrc/emcstfe/models/nrs/cancelMovement/CancelMovementNRSSubmissionSpec.scala
+++ b/test/uk/gov/hmrc/emcstfe/models/nrs/cancelMovement/CancelMovementNRSSubmissionSpec.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.emcstfe.models.nrs.cancelMovement
 
 import uk.gov.hmrc.emcstfe.fixtures.SubmitCancellationOfMovementFixtures
 import uk.gov.hmrc.emcstfe.models.cancellationOfMovement.SubmitCancellationOfMovementModel
+import uk.gov.hmrc.emcstfe.models.nrs.NotableEvent.CancelMovementNotableEvent
 import uk.gov.hmrc.emcstfe.support.TestBaseSpec
 
 class CancelMovementNRSSubmissionSpec extends TestBaseSpec with SubmitCancellationOfMovementFixtures {
@@ -25,9 +26,11 @@ class CancelMovementNRSSubmissionSpec extends TestBaseSpec with SubmitCancellati
   ".apply" should {
 
     s"generate the correct model from the $SubmitCancellationOfMovementModel" in {
+      CancelMovementNRSSubmission(maxSubmitCancellationOfMovementModel, testErn) shouldBe cancelMovementNRSSubmission
+    }
 
-      CancelMovementNRSSubmission.apply(maxSubmitCancellationOfMovementModel, testErn) shouldBe cancelMovementNRSSubmission
+    "have the correct notableEvent" in {
+      CancelMovementNRSSubmission(maxSubmitCancellationOfMovementModel, testErn).notableEvent shouldBe CancelMovementNotableEvent
     }
   }
-
 }

--- a/test/uk/gov/hmrc/emcstfe/models/nrs/createMovement/CreateMovementNRSSubmissionSpec.scala
+++ b/test/uk/gov/hmrc/emcstfe/models/nrs/createMovement/CreateMovementNRSSubmissionSpec.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.emcstfe.models.nrs.createMovement
+
+import play.api.libs.json.Json
+import uk.gov.hmrc.emcstfe.fixtures.CreateMovementFixtures
+import uk.gov.hmrc.emcstfe.models.nrs.NotableEvent.CreateMovementNotableEvent
+import uk.gov.hmrc.emcstfe.support.TestBaseSpec
+
+class CreateMovementNRSSubmissionSpec extends TestBaseSpec with CreateMovementFixtures {
+
+  "Must serialize to JSON correctly" in {
+    Json.toJson(CreateMovementNRSSubmission(testErn, CreateMovementFixtures.createMovementModelMax)) shouldBe
+      CreateMovementFixtures.createMovementJsonMax.deepMerge(Json.obj("exciseRegistrationNumber" -> testErn))
+  }
+
+  "have the correct notableEvent" in {
+    CreateMovementNRSSubmission(testErn, CreateMovementFixtures.createMovementModelMax).notableEvent shouldBe CreateMovementNotableEvent
+  }
+}

--- a/test/uk/gov/hmrc/emcstfe/models/nrs/explainDelay/ExplainDelayNRSSubmissionSpec.scala
+++ b/test/uk/gov/hmrc/emcstfe/models/nrs/explainDelay/ExplainDelayNRSSubmissionSpec.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.emcstfe.models.nrs.explainDelay
 
 import uk.gov.hmrc.emcstfe.fixtures.SubmitExplainDelayFixtures
 import uk.gov.hmrc.emcstfe.models.explainDelay.SubmitExplainDelayModel
+import uk.gov.hmrc.emcstfe.models.nrs.NotableEvent.ExplainDelayNotableEvent
 import uk.gov.hmrc.emcstfe.support.TestBaseSpec
 
 class ExplainDelayNRSSubmissionSpec extends TestBaseSpec with SubmitExplainDelayFixtures {
@@ -25,8 +26,11 @@ class ExplainDelayNRSSubmissionSpec extends TestBaseSpec with SubmitExplainDelay
   ".apply" should {
 
     s"generate the correct model from the $SubmitExplainDelayModel" in {
+      ExplainDelayNRSSubmission(maxSubmitExplainDelayModel) shouldBe explainDelayNRSSubmission
+    }
 
-      ExplainDelayNRSSubmission.apply(maxSubmitExplainDelayModel) shouldBe explainDelayNRSSubmission
+    "have the correct notableEvent" in {
+      ExplainDelayNRSSubmission(maxSubmitExplainDelayModel).notableEvent shouldBe ExplainDelayNotableEvent
     }
   }
 }

--- a/test/uk/gov/hmrc/emcstfe/models/nrs/explainShortageExcess/ExplainShortageExcessNRSSubmissionSpec.scala
+++ b/test/uk/gov/hmrc/emcstfe/models/nrs/explainShortageExcess/ExplainShortageExcessNRSSubmissionSpec.scala
@@ -19,6 +19,7 @@ package uk.gov.hmrc.emcstfe.models.nrs.explainShortageExcess
 import uk.gov.hmrc.emcstfe.fixtures.SubmitExplainShortageExcessFixtures
 import uk.gov.hmrc.emcstfe.models.common.SubmitterType.{Consignee, Consignor}
 import uk.gov.hmrc.emcstfe.models.explainShortageExcess.SubmitExplainShortageExcessModel
+import uk.gov.hmrc.emcstfe.models.nrs.NotableEvent.ExplainShortageOrExcessNotableEvent
 import uk.gov.hmrc.emcstfe.support.TestBaseSpec
 
 class ExplainShortageExcessNRSSubmissionSpec extends TestBaseSpec with SubmitExplainShortageExcessFixtures {
@@ -27,12 +28,16 @@ class ExplainShortageExcessNRSSubmissionSpec extends TestBaseSpec with SubmitExp
 
     s"generate the correct model from the $SubmitExplainShortageExcessModel" in {
 
-      ExplainShortageExcessNRSSubmission
-        .apply(SubmitExplainShortageExcessFixtures.submitExplainShortageExcessModelMax(Consignee), testErn) shouldBe explainShortageExcessNRSSubmission(Consignee, testErn)
+      ExplainShortageExcessNRSSubmission(SubmitExplainShortageExcessFixtures.submitExplainShortageExcessModelMax(Consignee), testErn) shouldBe
+        explainShortageExcessNRSSubmission(Consignee, testErn)
 
-      ExplainShortageExcessNRSSubmission
-        .apply(SubmitExplainShortageExcessFixtures.submitExplainShortageExcessModelMax(Consignor), testErn) shouldBe explainShortageExcessNRSSubmission(Consignor, testErn)
+      ExplainShortageExcessNRSSubmission(SubmitExplainShortageExcessFixtures.submitExplainShortageExcessModelMax(Consignor), testErn) shouldBe
+        explainShortageExcessNRSSubmission(Consignor, testErn)
+    }
+
+    "have the correct notableEvent" in {
+      ExplainShortageExcessNRSSubmission(SubmitExplainShortageExcessFixtures.submitExplainShortageExcessModelMax(Consignor), testErn).notableEvent shouldBe
+        ExplainShortageOrExcessNotableEvent
     }
   }
-
 }

--- a/test/uk/gov/hmrc/emcstfe/models/nrs/reportOfReceipt/ReportOfReceiptNRSSubmissionSpec.scala
+++ b/test/uk/gov/hmrc/emcstfe/models/nrs/reportOfReceipt/ReportOfReceiptNRSSubmissionSpec.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.emcstfe.models.nrs.reportOfReceipt
 
 import uk.gov.hmrc.emcstfe.fixtures.{SubmitExplainShortageExcessFixtures, SubmitReportOfReceiptFixtures}
-import uk.gov.hmrc.emcstfe.models.explainShortageExcess.SubmitExplainShortageExcessModel
+import uk.gov.hmrc.emcstfe.models.nrs.NotableEvent.ReportAReceiptNotableEvent
 import uk.gov.hmrc.emcstfe.models.reportOfReceipt.SubmitReportOfReceiptModel
 import uk.gov.hmrc.emcstfe.support.TestBaseSpec
 
@@ -26,9 +26,11 @@ class ReportOfReceiptNRSSubmissionSpec extends TestBaseSpec with SubmitExplainSh
   ".apply" should {
 
     s"generate the correct model from the $SubmitReportOfReceiptModel" in {
+      ReportOfReceiptNRSSubmission(maxSubmitReportOfReceiptModel, testErn) shouldBe reportOfReceiptNRSSubmission
+    }
 
-      ReportOfReceiptNRSSubmission
-        .apply(maxSubmitReportOfReceiptModel, testErn) shouldBe reportOfReceiptNRSSubmission
+    "have the correct notableEvent" in {
+      ReportOfReceiptNRSSubmission(maxSubmitReportOfReceiptModel, testErn).notableEvent shouldBe ReportAReceiptNotableEvent
     }
   }
 }


### PR DESCRIPTION
Note:
- Includes refactor to introduce a `NRSSubmission` trait that contains the `NotableEvent` val, which is then concretely implemented as part of the classes which extend the NRSSubmission. This allows the test fixtures to be simplified and avoids having to maintain hashed strings of Base64 encoded submissions and SHA256 signatures.