### PR TITLE
[ETFE-3119] Remove Export as a submission type (FS4.1)

### DIFF
--- a/app/uk/gov/hmrc/emcstfe/models/createMovement/SubmissionMessageType.scala
+++ b/app/uk/gov/hmrc/emcstfe/models/createMovement/SubmissionMessageType.scala
@@ -23,12 +23,10 @@ sealed trait SubmissionMessageType
 object SubmissionMessageType extends Enumerable.Implicits {
   case object Standard extends WithName("1") with SubmissionMessageType
 
-  case object Export extends WithName("2") with SubmissionMessageType
-
   case object DutyPaidB2B extends WithName("3") with SubmissionMessageType
 
   val values: Seq[SubmissionMessageType] = Seq(
-    Standard, Export, DutyPaidB2B
+    Standard, DutyPaidB2B
   )
 
   implicit val enumerable: Enumerable[SubmissionMessageType] =


### PR DESCRIPTION
This is just to tidy up the model in the backend. The value is actually set by the frontend, separate PR for that main change is here:
- https://github.com/hmrc/emcs-tfe-create-movement-frontend/pull/294