### PR TITLE
[ETFE-3918] Trim the CDATA block before base64 encoding and sending to EIS

### DIFF
--- a/app/uk/gov/hmrc/emcstfe/models/request/eis/EisMessage.scala
+++ b/app/uk/gov/hmrc/emcstfe/models/request/eis/EisMessage.scala
@@ -58,7 +58,7 @@ trait EisMessage extends XmlWriterUtils {
       <con:OperationRequest>
         <con:Parameters>
           <con:Parameter Name="ExciseRegistrationNumber">{exciseRegistrationNumber}</con:Parameter>
-          <con:Parameter Name="message">{PCData(xml.toString())}</con:Parameter>
+          <con:Parameter Name="message">{PCData(trimWhitespaceFromXml(xml).toString())}</con:Parameter>
         </con:Parameters>
         <con:ReturnData/>
       </con:OperationRequest>

--- a/test/uk/gov/hmrc/emcstfe/models/request/SubmitAlertOrRejectionRequestSpec.scala
+++ b/test/uk/gov/hmrc/emcstfe/models/request/SubmitAlertOrRejectionRequestSpec.scala
@@ -222,8 +222,7 @@ class SubmitAlertOrRejectionRequestSpec extends TestBaseSpec with SubmitAlertOrR
         val requestXml = XML.loadString(request.eisXMLBody())
         val expectedXml = trim(expectedRequest)
 
-        requestXml.getControlDocWithoutMessage.toString() shouldEqual expectedXml.getControlDocWithoutMessage.toString()
-        requestXml.getMessageBody.toString() shouldEqual expectedXml.getMessageBody.toString()
+        requestXml shouldBe expectedXml
       }
     }
 
@@ -261,8 +260,7 @@ class SubmitAlertOrRejectionRequestSpec extends TestBaseSpec with SubmitAlertOrR
         val requestXml = XML.loadString(request.eisXMLBody())
         val expectedXml = trim(expectedRequest)
 
-        requestXml.getControlDocWithoutMessage.toString() shouldEqual expectedXml.getControlDocWithoutMessage.toString()
-        requestXml.getMessageBody.toString() shouldEqual expectedXml.getMessageBody.toString()
+        requestXml shouldBe expectedXml
       }
     }
   }

--- a/test/uk/gov/hmrc/emcstfe/models/request/SubmitCancellationOfMovementRequestSpec.scala
+++ b/test/uk/gov/hmrc/emcstfe/models/request/SubmitCancellationOfMovementRequestSpec.scala
@@ -248,8 +248,7 @@ class SubmitCancellationOfMovementRequestSpec extends TestBaseSpec with SubmitCa
         val requestXml = XML.loadString(request.eisXMLBody())
         val expectedXml = trim(expectedRequest)
 
-        requestXml.getControlDocWithoutMessage.toString() shouldEqual expectedXml.getControlDocWithoutMessage.toString()
-        requestXml.getMessageBody.toString() shouldEqual expectedXml.getMessageBody.toString()
+        requestXml shouldBe expectedXml
       }
     }
 
@@ -288,8 +287,7 @@ class SubmitCancellationOfMovementRequestSpec extends TestBaseSpec with SubmitCa
         val requestXml = XML.loadString(request.eisXMLBody())
         val expectedXml = trim(expectedRequest)
 
-        requestXml.getControlDocWithoutMessage.toString() shouldEqual expectedXml.getControlDocWithoutMessage.toString()
-        requestXml.getMessageBody.toString() shouldEqual expectedXml.getMessageBody.toString()
+        requestXml shouldBe expectedXml
       }
     }
   }

--- a/test/uk/gov/hmrc/emcstfe/models/request/SubmitChangeDestinationRequestSpec.scala
+++ b/test/uk/gov/hmrc/emcstfe/models/request/SubmitChangeDestinationRequestSpec.scala
@@ -265,8 +265,7 @@ class SubmitChangeDestinationRequestSpec extends TestBaseSpec with SubmitChangeD
         val requestXml = XML.loadString(request.eisXMLBody())
         val expectedXml = trim(expectedRequest)
 
-        requestXml.getControlDocWithoutMessage.toString() shouldEqual expectedXml.getControlDocWithoutMessage.toString()
-        requestXml.getMessageBody.toString() shouldEqual expectedXml.getMessageBody.toString()
+        requestXml shouldBe expectedXml
       }
     }
 
@@ -304,8 +303,7 @@ class SubmitChangeDestinationRequestSpec extends TestBaseSpec with SubmitChangeD
         val requestXml = XML.loadString(request.eisXMLBody())
         val expectedXml = trim(expectedRequest)
 
-        requestXml.getControlDocWithoutMessage.toString() shouldEqual expectedXml.getControlDocWithoutMessage.toString()
-        requestXml.getMessageBody.toString() shouldEqual expectedXml.getMessageBody.toString()
+        requestXml shouldBe expectedXml
       }
     }
   }

--- a/test/uk/gov/hmrc/emcstfe/models/request/SubmitCreateMovementRequestSpec.scala
+++ b/test/uk/gov/hmrc/emcstfe/models/request/SubmitCreateMovementRequestSpec.scala
@@ -425,8 +425,7 @@ class SubmitCreateMovementRequestSpec extends TestBaseSpec with CreateMovementFi
         val requestXml = XML.loadString(request.eisXMLBody())
         val expectedXml = trim(expectedRequest)
 
-        requestXml.getControlDocWithoutMessage.toString() shouldEqual expectedXml.getControlDocWithoutMessage.toString()
-        requestXml.getMessageBody.toString() shouldEqual expectedXml.getMessageBody.toString()
+        requestXml shouldBe expectedXml
       }
     }
 
@@ -467,8 +466,7 @@ class SubmitCreateMovementRequestSpec extends TestBaseSpec with CreateMovementFi
         val requestXml = XML.loadString(request.eisXMLBody())
         val expectedXml = trim(expectedRequest)
 
-        requestXml.getControlDocWithoutMessage.toString() shouldEqual expectedXml.getControlDocWithoutMessage.toString()
-        requestXml.getMessageBody.toString() shouldEqual expectedXml.getMessageBody.toString()
+        requestXml shouldBe expectedXml
       }
     }
   }

--- a/test/uk/gov/hmrc/emcstfe/models/request/SubmitExplainDelayRequestSpec.scala
+++ b/test/uk/gov/hmrc/emcstfe/models/request/SubmitExplainDelayRequestSpec.scala
@@ -213,8 +213,7 @@ class SubmitExplainDelayRequestSpec extends TestBaseSpec with SubmitExplainDelay
         val requestXml = XML.loadString(request.eisXMLBody())
         val expectedXml = trim(expectedRequest)
 
-        requestXml.getControlDocWithoutMessage.toString() shouldEqual expectedXml.getControlDocWithoutMessage.toString()
-        requestXml.getMessageBody.toString() shouldEqual expectedXml.getMessageBody.toString()
+        requestXml shouldBe expectedXml
       }
     }
 
@@ -251,8 +250,7 @@ class SubmitExplainDelayRequestSpec extends TestBaseSpec with SubmitExplainDelay
         val requestXml = XML.loadString(request.eisXMLBody())
         val expectedXml = trim(expectedRequest)
 
-        requestXml.getControlDocWithoutMessage.toString() shouldEqual expectedXml.getControlDocWithoutMessage.toString()
-        requestXml.getMessageBody.toString() shouldEqual expectedXml.getMessageBody.toString()
+        requestXml shouldBe expectedXml
       }
     }
   }

--- a/test/uk/gov/hmrc/emcstfe/models/request/SubmitExplainShortageExcessRequestSpec.scala
+++ b/test/uk/gov/hmrc/emcstfe/models/request/SubmitExplainShortageExcessRequestSpec.scala
@@ -288,8 +288,7 @@ class SubmitExplainShortageExcessRequestSpec extends TestBaseSpec with SubmitExp
             val requestXml = XML.loadString(request.eisXMLBody())
             val expectedXml = trim(expectedRequest)
 
-            requestXml.getControlDocWithoutMessage.toString() shouldEqual expectedXml.getControlDocWithoutMessage.toString()
-            requestXml.getMessageBody.toString() shouldEqual expectedXml.getMessageBody.toString()
+            requestXml shouldBe expectedXml
           }
         }
 
@@ -328,8 +327,7 @@ class SubmitExplainShortageExcessRequestSpec extends TestBaseSpec with SubmitExp
             val requestXml = XML.loadString(request.eisXMLBody())
             val expectedXml = trim(expectedRequest)
 
-            requestXml.getControlDocWithoutMessage.toString() shouldEqual expectedXml.getControlDocWithoutMessage.toString()
-            requestXml.getMessageBody.toString() shouldEqual expectedXml.getMessageBody.toString()
+            requestXml shouldBe expectedXml
           }
         }
       }

--- a/test/uk/gov/hmrc/emcstfe/models/request/SubmitReportOfReceiptRequestSpec.scala
+++ b/test/uk/gov/hmrc/emcstfe/models/request/SubmitReportOfReceiptRequestSpec.scala
@@ -308,8 +308,7 @@ class SubmitReportOfReceiptRequestSpec extends TestBaseSpec with SubmitReportOfR
         val requestXml = XML.loadString(request.eisXMLBody())
         val expectedXml = trim(expectedRequest)
 
-        requestXml.getControlDocWithoutMessage.toString() shouldEqual expectedXml.getControlDocWithoutMessage.toString()
-        requestXml.getMessageBody.toString() shouldEqual expectedXml.getMessageBody.toString()
+        requestXml shouldBe expectedXml
       }
     }
 
@@ -350,8 +349,7 @@ class SubmitReportOfReceiptRequestSpec extends TestBaseSpec with SubmitReportOfR
         val requestXml = XML.loadString(request.eisXMLBody())
         val expectedXml = trim(expectedRequest)
 
-        requestXml.getControlDocWithoutMessage.toString() shouldEqual expectedXml.getControlDocWithoutMessage.toString()
-        requestXml.getMessageBody.toString() shouldEqual expectedXml.getMessageBody.toString()
+        requestXml shouldBe expectedXml
       }
     }
   }

--- a/test/uk/gov/hmrc/emcstfe/support/TestBaseSpec.scala
+++ b/test/uk/gov/hmrc/emcstfe/support/TestBaseSpec.scala
@@ -20,25 +20,9 @@ import org.scalamock.scalatest.MockFactory
 import uk.gov.hmrc.emcstfe.models.request.eis.EisSubmissionRequest
 
 import scala.xml.Utility.trim
-import scala.xml.transform.{RewriteRule, RuleTransformer}
-import scala.xml.{Elem, Node, NodeSeq, XML}
+import scala.xml.{Node, XML}
 
 trait TestBaseSpec extends UnitSpec with MockFactory {
-  implicit class TestXMLClassOps(n: NodeSeq) {
-    def getMessageBody: NodeSeq = trim(XML.loadString((n \\ "Parameter" filter {
-      _ \ "@Name" exists (_.text == "message")
-    }).text))
-
-    def getControlDocWithoutMessage: NodeSeq = {
-      val removeMessageFromControl: RewriteRule = new RewriteRule {
-        override def transform(n: Node): NodeSeq = n match {
-          case e: Elem if (e \ "@Name").text == "message" & e.label == "Parameter" => NodeSeq.Empty
-          case n => n
-        }
-      }
-      new RuleTransformer(removeMessageFromControl).transform(n)
-    }
-  }
 
   def wrapInControlDoc(xml: Node)(implicit request: EisSubmissionRequest): Node =
     <con:Control xmlns:con="http://www.govtalk.gov.uk/taxation/InternationalTrade/Common/ControlDocument">
@@ -56,7 +40,7 @@ trait TestBaseSpec extends UnitSpec with MockFactory {
           <con:Parameter Name="ExciseRegistrationNumber">{request.exciseRegistrationNumber}</con:Parameter>
           {XML.loadString(s"""
                              |<con:Parameter Name="message">
-                             |<![CDATA[$xml]]>
+                             |<![CDATA[${trim(xml)}]]>
                              |</con:Parameter>
                              """.stripMargin)}
           </con:Parameters>


### PR DESCRIPTION
~~Draft, **TBC** if we want to do this.~~

ATS have confirmed that this fixes some issues they were experiencing in QA. It's also probably a good change to minimise the size of the payload being sent to core. 