### PR TITLE
[ETFE-4343] Handle both ChRIS and EIS message date preparation time for events

### DIFF
--- a/app/uk/gov/hmrc/emcstfe/models/response/getMovement/NotificationOfAlertOrRejectionModel.scala
+++ b/app/uk/gov/hmrc/emcstfe/models/response/getMovement/NotificationOfAlertOrRejectionModel.scala
@@ -16,32 +16,43 @@
 
 package uk.gov.hmrc.emcstfe.models.response.getMovement
 
-import cats.implicits.catsSyntaxTuple3Semigroupal
+import cats.implicits.catsSyntaxTuple4Semigroupal
 import com.lucidchart.open.xtract.XmlReader.strictReadSeq
 import com.lucidchart.open.xtract.{XPath, XmlReader, __}
 import play.api.libs.json.{Format, Json}
 import uk.gov.hmrc.emcstfe.models.alertOrRejection.AlertOrRejectionType
+import uk.gov.hmrc.emcstfe.utils.DateUtils
 import uk.gov.hmrc.emcstfe.utils.LocalDateTimeXMLReader._
 
-import java.time.LocalDateTime
+import java.time.{LocalDate, LocalDateTime, LocalTime}
 
 case class NotificationOfAlertOrRejectionModel(notificationType: AlertOrRejectionType,
                                                notificationDateAndTime: LocalDateTime,
                                                alertRejectReason: Seq[AlertOrRejectionReasonModel])
 
-object NotificationOfAlertOrRejectionModel {
+object NotificationOfAlertOrRejectionModel extends DateUtils {
 
   implicit val format: Format[NotificationOfAlertOrRejectionModel] = Json.format[NotificationOfAlertOrRejectionModel]
 
   private lazy val notificationType: XPath = __ \\ "EadEsadRejectedFlag"
 
-  private lazy val notificationDateTime: XPath = __ \\ "DateAndTimeOfValidationOfAlertRejection"
+  private lazy val notificationDate: XPath = __ \\ "DateOfPreparation"
+  private lazy val notificationTime: XPath = __ \\ "TimeOfPreparation"
 
   private lazy val alertRejectReason: XPath = __ \\ "AlertOrRejectionOfEadEsadReason"
 
   implicit lazy val xmlReads: XmlReader[NotificationOfAlertOrRejectionModel] = (
     notificationType.read[AlertOrRejectionType](AlertOrRejectionType.xmlReads("EadEsadRejectedFlag")(AlertOrRejectionType.enumerable)),
-    notificationDateTime.read[LocalDateTime],
+    notificationDate.read[LocalDate],
+    notificationTime.read[LocalTime],
     alertRejectReason.read[Seq[AlertOrRejectionReasonModel]](strictReadSeq)
   ).mapN(NotificationOfAlertOrRejectionModel.apply)
+
+  def apply(notificationType: AlertOrRejectionType,
+            notificationDate: LocalDate,
+            notificationTime: LocalTime,
+            alertRejectReason: Seq[AlertOrRejectionReasonModel]): NotificationOfAlertOrRejectionModel =
+    NotificationOfAlertOrRejectionModel(
+      notificationType, LocalDateTime.of(notificationDate, notificationTime.roundToNearestSecond()), alertRejectReason
+    )
 }

--- a/app/uk/gov/hmrc/emcstfe/utils/DateUtils.scala
+++ b/app/uk/gov/hmrc/emcstfe/utils/DateUtils.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.emcstfe.utils
+
+import java.time._
+import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
+import java.util.Locale
+import scala.util.{Failure, Success, Try}
+
+trait DateUtils {
+
+  implicit class LocalTimeExtensions(time: LocalTime) {
+    def roundToNearestSecond(): LocalTime =
+      (if(time.getNano >= 500000000) time.plusSeconds(1) else time).truncatedTo(ChronoUnit.SECONDS)
+  }
+}

--- a/app/uk/gov/hmrc/emcstfe/utils/LocalDateTimeXMLReader.scala
+++ b/app/uk/gov/hmrc/emcstfe/utils/LocalDateTimeXMLReader.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.emcstfe.utils
 
 import com.lucidchart.open.xtract.{ParseError, ParseFailure, ParseSuccess, XmlReader}
 
-import java.time.LocalDateTime
+import java.time.{LocalDate, LocalDateTime, LocalTime}
 import scala.util.{Failure, Success, Try}
 import scala.xml.NodeSeq
 
@@ -28,6 +28,18 @@ object LocalDateTimeXMLReader {
 
   implicit val xmlLocalDateTimeReads: XmlReader[LocalDateTime] = (xml: NodeSeq) =>
     Try(LocalDateTime.parse(xml.text)) match {
+      case Success(value) => ParseSuccess(value)
+      case Failure(e)     => ParseFailure(LocalDateTimeParseFailure(e.getMessage))
+    }
+
+  implicit val xmlLocalDateReads: XmlReader[LocalDate] = (xml: NodeSeq) =>
+    Try(LocalDate.parse(xml.text)) match {
+      case Success(value) => ParseSuccess(value)
+      case Failure(e)     => ParseFailure(LocalDateTimeParseFailure(e.getMessage))
+    }
+
+  implicit val xmlLocalTimeReads: XmlReader[LocalTime] = (xml: NodeSeq) =>
+    Try(LocalTime.parse(xml.text)) match {
       case Success(value) => ParseSuccess(value)
       case Failure(e)     => ParseFailure(LocalDateTimeParseFailure(e.getMessage))
     }

--- a/test/uk/gov/hmrc/emcstfe/fixtures/GetMovementFixture.scala
+++ b/test/uk/gov/hmrc/emcstfe/fixtures/GetMovementFixture.scala
@@ -429,8 +429,8 @@ trait GetMovementFixture extends BaseFixtures with TraderModelFixtures {
        |        <body:Header xmlns:head="urn:publicid:-:EC:DGTAXUD:EMCS:PHASE3:TMS:V2.02">
        |          <head:MessageSender>token</head:MessageSender>
        |          <head:MessageRecipient>token</head:MessageRecipient>
-       |          <head:DateOfPreparation>1967-08-13</head:DateOfPreparation>
-       |          <head:TimeOfPreparation>14:20:00</head:TimeOfPreparation>
+       |          <head:DateOfPreparation>2001-12-17</head:DateOfPreparation>
+       |          <head:TimeOfPreparation>09:30:47</head:TimeOfPreparation>
        |          <head:MessageIdentifier>token</head:MessageIdentifier>
        |          <head:CorrelationIdentifier>token</head:CorrelationIdentifier>
        |        </body:Header>
@@ -442,7 +442,7 @@ trait GetMovementFixture extends BaseFixtures with TraderModelFixtures {
        |              <body:ExplanationCode>1</body:ExplanationCode>
        |              <body:ComplementaryInformation language="to">837 complementary info</body:ComplementaryInformation>
        |              <body:MessageRole>1</body:MessageRole>
-       |              <body:DateAndTimeOfValidationOfExplanationOnDelay>2001-12-17T09:30:47.00</body:DateAndTimeOfValidationOfExplanationOnDelay>
+       |              <body:DateAndTimeOfValidationOfExplanationOnDelay>2001-12-17T09:30:48</body:DateAndTimeOfValidationOfExplanationOnDelay>
        |            </body:Attributes>
        |            <body:ExciseMovement>
        |              <body:AdministrativeReferenceCode>13AB1234567891ABCDEF9</body:AdministrativeReferenceCode>
@@ -501,14 +501,14 @@ trait GetMovementFixture extends BaseFixtures with TraderModelFixtures {
        |          <urn:MessageSender>NDEA.GB</urn:MessageSender>
        |          <urn:MessageRecipient>NDEA.GB</urn:MessageRecipient>
        |          <urn:DateOfPreparation>2023-12-18</urn:DateOfPreparation>
-       |          <urn:TimeOfPreparation>08:59:59.441503</urn:TimeOfPreparation>
+       |          <urn:TimeOfPreparation>09:00:00</urn:TimeOfPreparation>
        |          <urn:MessageIdentifier>9de3f13e-7559-4f4d-8851-b954b01210c0</urn:MessageIdentifier>
        |          <urn:CorrelationIdentifier>e8803427-c7e5-4539-83b7-d174f511e70c</urn:CorrelationIdentifier>
        |        </ie819:Header>
        |        <ie819:Body>
        |          <ie819:AlertOrRejectionOfEADESAD>
        |            <ie819:Attributes>
-       |              <ie819:DateAndTimeOfValidationOfAlertRejection>2023-12-18T09:00:00</ie819:DateAndTimeOfValidationOfAlertRejection>
+       |              <ie819:DateAndTimeOfValidationOfAlertRejection>2023-12-18T09:00:01</ie819:DateAndTimeOfValidationOfAlertRejection>
        |            </ie819:Attributes>
        |            <ie819:ConsigneeTrader language="en">
        |              <ie819:Traderid>GBWK123456789</ie819:Traderid>
@@ -554,14 +554,14 @@ trait GetMovementFixture extends BaseFixtures with TraderModelFixtures {
        |          <urn:MessageSender>NDEA.GB</urn:MessageSender>
        |          <urn:MessageRecipient>NDEA.GB</urn:MessageRecipient>
        |          <urn:DateOfPreparation>2023-12-18</urn:DateOfPreparation>
-       |          <urn:TimeOfPreparation>09:59:59.441503</urn:TimeOfPreparation>
+       |          <urn:TimeOfPreparation>10:00:00</urn:TimeOfPreparation>
        |          <urn:MessageIdentifier>9de3f13e-7559-4f4d-8851-b954b01210c0</urn:MessageIdentifier>
        |          <urn:CorrelationIdentifier>e8803427-c7e5-4539-83b7-d174f511e70c</urn:CorrelationIdentifier>
        |        </ie819:Header>
        |        <ie819:Body>
        |          <ie819:AlertOrRejectionOfEADESAD>
        |            <ie819:Attributes>
-       |              <ie819:DateAndTimeOfValidationOfAlertRejection>2023-12-18T10:00:00</ie819:DateAndTimeOfValidationOfAlertRejection>
+       |              <ie819:DateAndTimeOfValidationOfAlertRejection>2023-12-18T10:00:01</ie819:DateAndTimeOfValidationOfAlertRejection>
        |            </ie819:Attributes>
        |            <ie819:ConsigneeTrader language="en">
        |              <ie819:Traderid>GBWK123456789</ie819:Traderid>
@@ -594,14 +594,14 @@ trait GetMovementFixture extends BaseFixtures with TraderModelFixtures {
        |          <urn:MessageSender>NDEA.GB</urn:MessageSender>
        |          <urn:MessageRecipient>NDEA.GB</urn:MessageRecipient>
        |          <urn:DateOfPreparation>2023-12-19</urn:DateOfPreparation>
-       |          <urn:TimeOfPreparation>08:59:59.441503</urn:TimeOfPreparation>
+       |          <urn:TimeOfPreparation>09:00:00</urn:TimeOfPreparation>
        |          <urn:MessageIdentifier>9de3f13e-7559-4f4d-8851-b954b01210c0</urn:MessageIdentifier>
        |          <urn:CorrelationIdentifier>e8803427-c7e5-4539-83b7-d174f511e70c</urn:CorrelationIdentifier>
        |        </ie819:Header>
        |        <ie819:Body>
        |          <ie819:AlertOrRejectionOfEADESAD>
        |            <ie819:Attributes>
-       |              <ie819:DateAndTimeOfValidationOfAlertRejection>2023-12-19T09:00:00</ie819:DateAndTimeOfValidationOfAlertRejection>
+       |              <ie819:DateAndTimeOfValidationOfAlertRejection>2023-12-19T09:00:01</ie819:DateAndTimeOfValidationOfAlertRejection>
        |            </ie819:Attributes>
        |            <ie819:ConsigneeTrader language="en">
        |              <ie819:Traderid>GBWK123456789</ie819:Traderid>
@@ -677,7 +677,7 @@ trait GetMovementFixture extends BaseFixtures with TraderModelFixtures {
        |            <urn:MessageSender>NDEA.GB</urn:MessageSender>
        |            <urn:MessageRecipient>NDEA.GB</urn:MessageRecipient>
        |            <urn:DateOfPreparation>2024-06-18</urn:DateOfPreparation>
-       |            <urn:TimeOfPreparation>07:11:31.898476</urn:TimeOfPreparation>
+       |            <urn:TimeOfPreparation>08:11:32.500000</urn:TimeOfPreparation>
        |            <urn:MessageIdentifier>GB100000000305526</urn:MessageIdentifier>
        |            <urn:CorrelationIdentifier>PORTALb32df82fde8741b4beb3fb832a9cdb76</urn:CorrelationIdentifier>
        |         </ie837:Header>
@@ -689,7 +689,7 @@ trait GetMovementFixture extends BaseFixtures with TraderModelFixtures {
        |                  <ie837:ExplanationCode>6</ie837:ExplanationCode>
        |                  <ie837:ComplementaryInformation language="en">Lorry crashed off cliff</ie837:ComplementaryInformation>
        |                  <ie837:MessageRole>1</ie837:MessageRole>
-       |                  <ie837:DateAndTimeOfValidationOfExplanationOnDelay>2024-06-18T08:11:33</ie837:DateAndTimeOfValidationOfExplanationOnDelay>
+       |                  <ie837:DateAndTimeOfValidationOfExplanationOnDelay>2024-06-18T08:11:34</ie837:DateAndTimeOfValidationOfExplanationOnDelay>
        |               </ie837:Attributes>
        |               <ie837:ExciseMovement>
        |                  <ie837:AdministrativeReferenceCode>18GB00000000000232361</ie837:AdministrativeReferenceCode>
@@ -705,7 +705,7 @@ trait GetMovementFixture extends BaseFixtures with TraderModelFixtures {
        |            <urn:MessageSender>NDEA.GB</urn:MessageSender>
        |            <urn:MessageRecipient>NDEA.GB</urn:MessageRecipient>
        |            <urn:DateOfPreparation>2024-06-18</urn:DateOfPreparation>
-       |            <urn:TimeOfPreparation>07:18:54.852159</urn:TimeOfPreparation>
+       |            <urn:TimeOfPreparation>08:18:56.499999</urn:TimeOfPreparation>
        |            <urn:MessageIdentifier>GB100000000305527</urn:MessageIdentifier>
        |            <urn:CorrelationIdentifier>PORTAL07498cf951004becbc3c73c14c103b13</urn:CorrelationIdentifier>
        |         </ie837:Header>
@@ -716,7 +716,7 @@ trait GetMovementFixture extends BaseFixtures with TraderModelFixtures {
        |                  <ie837:SubmitterType>1</ie837:SubmitterType>
        |                  <ie837:ExplanationCode>5</ie837:ExplanationCode>
        |                  <ie837:MessageRole>2</ie837:MessageRole>
-       |                  <ie837:DateAndTimeOfValidationOfExplanationOnDelay>2024-06-18T08:18:56</ie837:DateAndTimeOfValidationOfExplanationOnDelay>
+       |                  <ie837:DateAndTimeOfValidationOfExplanationOnDelay>2024-06-18T08:18:57</ie837:DateAndTimeOfValidationOfExplanationOnDelay>
        |               </ie837:Attributes>
        |               <ie837:ExciseMovement>
        |                  <ie837:AdministrativeReferenceCode>18GB00000000000232361</ie837:AdministrativeReferenceCode>
@@ -1891,14 +1891,14 @@ trait GetMovementFixture extends BaseFixtures with TraderModelFixtures {
        |          <urn:MessageSender>NDEA.GB</urn:MessageSender>
        |          <urn:MessageRecipient>NDEA.GB</urn:MessageRecipient>
        |          <urn:DateOfPreparation>2023-12-18</urn:DateOfPreparation>
-       |          <urn:TimeOfPreparation>08:59:59.441503</urn:TimeOfPreparation>
+       |          <urn:TimeOfPreparation>09:00:00</urn:TimeOfPreparation>
        |          <urn:MessageIdentifier>9de3f13e-7559-4f4d-8851-b954b01210c0</urn:MessageIdentifier>
        |          <urn:CorrelationIdentifier>e8803427-c7e5-4539-83b7-d174f511e70c</urn:CorrelationIdentifier>
        |        </ie819:Header>
        |        <ie819:Body>
        |          <ie819:AlertOrRejectionOfEADESAD>
        |            <ie819:Attributes>
-       |              <ie819:DateAndTimeOfValidationOfAlertRejection>2023-12-18T09:00:00</ie819:DateAndTimeOfValidationOfAlertRejection>
+       |              <ie819:DateAndTimeOfValidationOfAlertRejection>2023-12-18T09:00:01</ie819:DateAndTimeOfValidationOfAlertRejection>
        |            </ie819:Attributes>
        |            <ie819:ConsigneeTrader language="en">
        |              <ie819:Traderid>GBWK123456789</ie819:Traderid>
@@ -1944,14 +1944,14 @@ trait GetMovementFixture extends BaseFixtures with TraderModelFixtures {
        |          <urn:MessageSender>NDEA.GB</urn:MessageSender>
        |          <urn:MessageRecipient>NDEA.GB</urn:MessageRecipient>
        |          <urn:DateOfPreparation>2023-12-18</urn:DateOfPreparation>
-       |          <urn:TimeOfPreparation>09:59:59.441503</urn:TimeOfPreparation>
+       |          <urn:TimeOfPreparation>10:00:00</urn:TimeOfPreparation>
        |          <urn:MessageIdentifier>9de3f13e-7559-4f4d-8851-b954b01210c0</urn:MessageIdentifier>
        |          <urn:CorrelationIdentifier>e8803427-c7e5-4539-83b7-d174f511e70c</urn:CorrelationIdentifier>
        |        </ie819:Header>
        |        <ie819:Body>
        |          <ie819:AlertOrRejectionOfEADESAD>
        |            <ie819:Attributes>
-       |              <ie819:DateAndTimeOfValidationOfAlertRejection>2023-12-18T10:00:00</ie819:DateAndTimeOfValidationOfAlertRejection>
+       |              <ie819:DateAndTimeOfValidationOfAlertRejection>2023-12-18T10:00:01</ie819:DateAndTimeOfValidationOfAlertRejection>
        |            </ie819:Attributes>
        |            <ie819:ConsigneeTrader language="en">
        |              <ie819:Traderid>GBWK123456789</ie819:Traderid>
@@ -1984,14 +1984,14 @@ trait GetMovementFixture extends BaseFixtures with TraderModelFixtures {
        |          <urn:MessageSender>NDEA.GB</urn:MessageSender>
        |          <urn:MessageRecipient>NDEA.GB</urn:MessageRecipient>
        |          <urn:DateOfPreparation>2023-12-19</urn:DateOfPreparation>
-       |          <urn:TimeOfPreparation>08:59:59.441503</urn:TimeOfPreparation>
+       |          <urn:TimeOfPreparation>09:00:00</urn:TimeOfPreparation>
        |          <urn:MessageIdentifier>9de3f13e-7559-4f4d-8851-b954b01210c0</urn:MessageIdentifier>
        |          <urn:CorrelationIdentifier>e8803427-c7e5-4539-83b7-d174f511e70c</urn:CorrelationIdentifier>
        |        </ie819:Header>
        |        <ie819:Body>
        |          <ie819:AlertOrRejectionOfEADESAD>
        |            <ie819:Attributes>
-       |              <ie819:DateAndTimeOfValidationOfAlertRejection>2023-12-19T09:00:00</ie819:DateAndTimeOfValidationOfAlertRejection>
+       |              <ie819:DateAndTimeOfValidationOfAlertRejection>2023-12-19T09:00:01</ie819:DateAndTimeOfValidationOfAlertRejection>
        |            </ie819:Attributes>
        |            <ie819:ConsigneeTrader language="en">
        |              <ie819:Traderid>GBWK123456789</ie819:Traderid>
@@ -2067,7 +2067,7 @@ trait GetMovementFixture extends BaseFixtures with TraderModelFixtures {
        |            <urn:MessageSender>NDEA.GB</urn:MessageSender>
        |            <urn:MessageRecipient>NDEA.GB</urn:MessageRecipient>
        |            <urn:DateOfPreparation>2024-06-18</urn:DateOfPreparation>
-       |            <urn:TimeOfPreparation>07:11:31.898476</urn:TimeOfPreparation>
+       |            <urn:TimeOfPreparation>08:11:33</urn:TimeOfPreparation>
        |            <urn:MessageIdentifier>GB100000000305526</urn:MessageIdentifier>
        |            <urn:CorrelationIdentifier>PORTALb32df82fde8741b4beb3fb832a9cdb76</urn:CorrelationIdentifier>
        |         </ie837:Header>
@@ -2079,7 +2079,7 @@ trait GetMovementFixture extends BaseFixtures with TraderModelFixtures {
        |                  <ie837:ExplanationCode>6</ie837:ExplanationCode>
        |                  <ie837:ComplementaryInformation language="en">Lorry crashed off cliff</ie837:ComplementaryInformation>
        |                  <ie837:MessageRole>1</ie837:MessageRole>
-       |                  <ie837:DateAndTimeOfValidationOfExplanationOnDelay>2024-06-18T08:11:33</ie837:DateAndTimeOfValidationOfExplanationOnDelay>
+       |                  <ie837:DateAndTimeOfValidationOfExplanationOnDelay>2024-06-18T08:11:34</ie837:DateAndTimeOfValidationOfExplanationOnDelay>
        |               </ie837:Attributes>
        |               <ie837:ExciseMovement>
        |                  <ie837:AdministrativeReferenceCode>18GB00000000000232361</ie837:AdministrativeReferenceCode>
@@ -2095,7 +2095,7 @@ trait GetMovementFixture extends BaseFixtures with TraderModelFixtures {
        |            <urn:MessageSender>NDEA.GB</urn:MessageSender>
        |            <urn:MessageRecipient>NDEA.GB</urn:MessageRecipient>
        |            <urn:DateOfPreparation>2024-06-18</urn:DateOfPreparation>
-       |            <urn:TimeOfPreparation>07:18:54.852159</urn:TimeOfPreparation>
+       |            <urn:TimeOfPreparation>08:18:56</urn:TimeOfPreparation>
        |            <urn:MessageIdentifier>GB100000000305527</urn:MessageIdentifier>
        |            <urn:CorrelationIdentifier>PORTAL07498cf951004becbc3c73c14c103b13</urn:CorrelationIdentifier>
        |         </ie837:Header>
@@ -2106,7 +2106,7 @@ trait GetMovementFixture extends BaseFixtures with TraderModelFixtures {
        |                  <ie837:SubmitterType>1</ie837:SubmitterType>
        |                  <ie837:ExplanationCode>5</ie837:ExplanationCode>
        |                  <ie837:MessageRole>2</ie837:MessageRole>
-       |                  <ie837:DateAndTimeOfValidationOfExplanationOnDelay>2024-06-18T08:18:56</ie837:DateAndTimeOfValidationOfExplanationOnDelay>
+       |                  <ie837:DateAndTimeOfValidationOfExplanationOnDelay>2024-06-18T08:18:57</ie837:DateAndTimeOfValidationOfExplanationOnDelay>
        |               </ie837:Attributes>
        |               <ie837:ExciseMovement>
        |                  <ie837:AdministrativeReferenceCode>18GB00000000000232361</ie837:AdministrativeReferenceCode>

--- a/test/uk/gov/hmrc/emcstfe/fixtures/GetMovementIfChangedFixture.scala
+++ b/test/uk/gov/hmrc/emcstfe/fixtures/GetMovementIfChangedFixture.scala
@@ -408,8 +408,8 @@ trait GetMovementIfChangedFixture extends BaseFixtures with TraderModelFixtures 
        |        <urn:Header xmlns:head="urn:publicid:-:EC:DGTAXUD:EMCS:PHASE3:TMS:V2.02">
        |          <head:MessageSender>token</head:MessageSender>
        |          <head:MessageRecipient>token</head:MessageRecipient>
-       |          <head:DateOfPreparation>1967-08-13</head:DateOfPreparation>
-       |          <head:TimeOfPreparation>14:20:00</head:TimeOfPreparation>
+       |          <head:DateOfPreparation>2001-12-17</head:DateOfPreparation>
+       |          <head:TimeOfPreparation>09:30:47</head:TimeOfPreparation>
        |          <head:MessageIdentifier>token</head:MessageIdentifier>
        |          <head:CorrelationIdentifier>token</head:CorrelationIdentifier>
        |        </urn:Header>
@@ -421,7 +421,7 @@ trait GetMovementIfChangedFixture extends BaseFixtures with TraderModelFixtures 
        |              <urn:ExplanationCode>1</urn:ExplanationCode>
        |              <urn:ComplementaryInformation language="to">837 complementary info</urn:ComplementaryInformation>
        |              <urn:MessageRole>1</urn:MessageRole>
-       |              <urn:DateAndTimeOfValidationOfExplanationOnDelay>2001-12-17T09:30:47.00</urn:DateAndTimeOfValidationOfExplanationOnDelay>
+       |              <urn:DateAndTimeOfValidationOfExplanationOnDelay>2001-12-17T09:30:48.00</urn:DateAndTimeOfValidationOfExplanationOnDelay>
        |            </urn:Attributes>
        |            <urn:ExciseMovement>
        |              <urn:AdministrativeReferenceCode>13AB1234567891ABCDEF9</urn:AdministrativeReferenceCode>

--- a/test/uk/gov/hmrc/emcstfe/models/response/getMovement/GetMovementResponseSpec.scala
+++ b/test/uk/gov/hmrc/emcstfe/models/response/getMovement/GetMovementResponseSpec.scala
@@ -702,7 +702,7 @@ class GetMovementResponseSpec extends TestBaseSpec with GetMovementFixture {
             |          <urn:MessageSender>NDEA.GB</urn:MessageSender>
             |          <urn:MessageRecipient>NDEA.GB</urn:MessageRecipient>
             |          <urn:DateOfPreparation>2023-12-18</urn:DateOfPreparation>
-            |          <urn:TimeOfPreparation>08:59:59.441503</urn:TimeOfPreparation>
+            |          <urn:TimeOfPreparation>08:59:59.541503</urn:TimeOfPreparation>
             |          <urn:MessageIdentifier>9de3f13e-7559-4f4d-8851-b954b01210c0</urn:MessageIdentifier>
             |          <urn:CorrelationIdentifier>e8803427-c7e5-4539-83b7-d174f511e70c</urn:CorrelationIdentifier>
             |        </ie819:Header>
@@ -755,7 +755,7 @@ class GetMovementResponseSpec extends TestBaseSpec with GetMovementFixture {
             |          <urn:MessageSender>NDEA.GB</urn:MessageSender>
             |          <urn:MessageRecipient>NDEA.GB</urn:MessageRecipient>
             |          <urn:DateOfPreparation>2023-12-18</urn:DateOfPreparation>
-            |          <urn:TimeOfPreparation>09:59:59.441503</urn:TimeOfPreparation>
+            |          <urn:TimeOfPreparation>09:59:59.541503</urn:TimeOfPreparation>
             |          <urn:MessageIdentifier>9de3f13e-7559-4f4d-8851-b954b01210c0</urn:MessageIdentifier>
             |          <urn:CorrelationIdentifier>e8803427-c7e5-4539-83b7-d174f511e70c</urn:CorrelationIdentifier>
             |        </ie819:Header>
@@ -795,7 +795,7 @@ class GetMovementResponseSpec extends TestBaseSpec with GetMovementFixture {
             |          <urn:MessageSender>NDEA.GB</urn:MessageSender>
             |          <urn:MessageRecipient>NDEA.GB</urn:MessageRecipient>
             |          <urn:DateOfPreparation>2023-12-19</urn:DateOfPreparation>
-            |          <urn:TimeOfPreparation>08:59:59.441503</urn:TimeOfPreparation>
+            |          <urn:TimeOfPreparation>08:59:59.541503</urn:TimeOfPreparation>
             |          <urn:MessageIdentifier>9de3f13e-7559-4f4d-8851-b954b01210c0</urn:MessageIdentifier>
             |          <urn:CorrelationIdentifier>e8803427-c7e5-4539-83b7-d174f511e70c</urn:CorrelationIdentifier>
             |        </ie819:Header>
@@ -875,8 +875,8 @@ class GetMovementResponseSpec extends TestBaseSpec with GetMovementFixture {
             |        <body:Header xmlns:head="urn:publicid:-:EC:DGTAXUD:EMCS:PHASE3:TMS:V2.02">
             |          <head:MessageSender>token</head:MessageSender>
             |          <head:MessageRecipient>token</head:MessageRecipient>
-            |          <head:DateOfPreparation>1967-08-13</head:DateOfPreparation>
-            |          <head:TimeOfPreparation>14:20:00</head:TimeOfPreparation>
+            |          <head:DateOfPreparation>2001-12-17</head:DateOfPreparation>
+            |          <head:TimeOfPreparation>09:30:47</head:TimeOfPreparation>
             |          <head:MessageIdentifier>token</head:MessageIdentifier>
             |          <head:CorrelationIdentifier>token</head:CorrelationIdentifier>
             |        </body:Header>
@@ -904,7 +904,7 @@ class GetMovementResponseSpec extends TestBaseSpec with GetMovementFixture {
             |            <urn:MessageSender>NDEA.GB</urn:MessageSender>
             |            <urn:MessageRecipient>NDEA.GB</urn:MessageRecipient>
             |            <urn:DateOfPreparation>2024-06-18</urn:DateOfPreparation>
-            |            <urn:TimeOfPreparation>07:11:31.898476</urn:TimeOfPreparation>
+            |            <urn:TimeOfPreparation>08:11:33</urn:TimeOfPreparation>
             |            <urn:MessageIdentifier>GB100000000305526</urn:MessageIdentifier>
             |            <urn:CorrelationIdentifier>PORTALb32df82fde8741b4beb3fb832a9cdb76</urn:CorrelationIdentifier>
             |         </ie837:Header>
@@ -932,7 +932,7 @@ class GetMovementResponseSpec extends TestBaseSpec with GetMovementFixture {
             |            <urn:MessageSender>NDEA.GB</urn:MessageSender>
             |            <urn:MessageRecipient>NDEA.GB</urn:MessageRecipient>
             |            <urn:DateOfPreparation>2024-06-18</urn:DateOfPreparation>
-            |            <urn:TimeOfPreparation>07:18:54.852159</urn:TimeOfPreparation>
+            |            <urn:TimeOfPreparation>08:18:56</urn:TimeOfPreparation>
             |            <urn:MessageIdentifier>GB100000000305527</urn:MessageIdentifier>
             |            <urn:CorrelationIdentifier>PORTAL07498cf951004becbc3c73c14c103b13</urn:CorrelationIdentifier>
             |         </ie837:Header>
@@ -1377,7 +1377,7 @@ class GetMovementResponseSpec extends TestBaseSpec with GetMovementFixture {
             |          <urn:MessageSender>NDEA.GB</urn:MessageSender>
             |          <urn:MessageRecipient>NDEA.GB</urn:MessageRecipient>
             |          <urn:DateOfPreparation>2023-12-18</urn:DateOfPreparation>
-            |          <urn:TimeOfPreparation>08:59:59.441503</urn:TimeOfPreparation>
+            |          <urn:TimeOfPreparation>08:59:59.541503</urn:TimeOfPreparation>
             |          <urn:MessageIdentifier>9de3f13e-7559-4f4d-8851-b954b01210c0</urn:MessageIdentifier>
             |          <urn:CorrelationIdentifier>e8803427-c7e5-4539-83b7-d174f511e70c</urn:CorrelationIdentifier>
             |        </ie819:Header>
@@ -1430,7 +1430,7 @@ class GetMovementResponseSpec extends TestBaseSpec with GetMovementFixture {
             |          <urn:MessageSender>NDEA.GB</urn:MessageSender>
             |          <urn:MessageRecipient>NDEA.GB</urn:MessageRecipient>
             |          <urn:DateOfPreparation>2023-12-18</urn:DateOfPreparation>
-            |          <urn:TimeOfPreparation>09:59:59.441503</urn:TimeOfPreparation>
+            |          <urn:TimeOfPreparation>09:59:59.541503</urn:TimeOfPreparation>
             |          <urn:MessageIdentifier>9de3f13e-7559-4f4d-8851-b954b01210c0</urn:MessageIdentifier>
             |          <urn:CorrelationIdentifier>e8803427-c7e5-4539-83b7-d174f511e70c</urn:CorrelationIdentifier>
             |        </ie819:Header>
@@ -1470,7 +1470,7 @@ class GetMovementResponseSpec extends TestBaseSpec with GetMovementFixture {
             |          <urn:MessageSender>NDEA.GB</urn:MessageSender>
             |          <urn:MessageRecipient>NDEA.GB</urn:MessageRecipient>
             |          <urn:DateOfPreparation>2023-12-19</urn:DateOfPreparation>
-            |          <urn:TimeOfPreparation>08:59:59.441503</urn:TimeOfPreparation>
+            |          <urn:TimeOfPreparation>08:59:59.541503</urn:TimeOfPreparation>
             |          <urn:MessageIdentifier>9de3f13e-7559-4f4d-8851-b954b01210c0</urn:MessageIdentifier>
             |          <urn:CorrelationIdentifier>e8803427-c7e5-4539-83b7-d174f511e70c</urn:CorrelationIdentifier>
             |        </ie819:Header>
@@ -1550,8 +1550,8 @@ class GetMovementResponseSpec extends TestBaseSpec with GetMovementFixture {
             |        <body:Header xmlns:head="urn:publicid:-:EC:DGTAXUD:EMCS:PHASE3:TMS:V2.02">
             |          <head:MessageSender>token</head:MessageSender>
             |          <head:MessageRecipient>token</head:MessageRecipient>
-            |          <head:DateOfPreparation>1967-08-13</head:DateOfPreparation>
-            |          <head:TimeOfPreparation>14:20:00</head:TimeOfPreparation>
+            |          <head:DateOfPreparation>2001-12-17</head:DateOfPreparation>
+            |          <head:TimeOfPreparation>09:30:47</head:TimeOfPreparation>
             |          <head:MessageIdentifier>token</head:MessageIdentifier>
             |          <head:CorrelationIdentifier>token</head:CorrelationIdentifier>
             |        </body:Header>
@@ -1579,7 +1579,7 @@ class GetMovementResponseSpec extends TestBaseSpec with GetMovementFixture {
             |            <urn:MessageSender>NDEA.GB</urn:MessageSender>
             |            <urn:MessageRecipient>NDEA.GB</urn:MessageRecipient>
             |            <urn:DateOfPreparation>2024-06-18</urn:DateOfPreparation>
-            |            <urn:TimeOfPreparation>07:11:31.898476</urn:TimeOfPreparation>
+            |            <urn:TimeOfPreparation>08:11:33</urn:TimeOfPreparation>
             |            <urn:MessageIdentifier>GB100000000305526</urn:MessageIdentifier>
             |            <urn:CorrelationIdentifier>PORTALb32df82fde8741b4beb3fb832a9cdb76</urn:CorrelationIdentifier>
             |         </ie837:Header>
@@ -1591,7 +1591,7 @@ class GetMovementResponseSpec extends TestBaseSpec with GetMovementFixture {
             |                  <ie837:ExplanationCode>6</ie837:ExplanationCode>
             |                  <ie837:ComplementaryInformation language="en">Lorry crashed off cliff</ie837:ComplementaryInformation>
             |                  <ie837:MessageRole>1</ie837:MessageRole>
-            |                  <ie837:DateAndTimeOfValidationOfExplanationOnDelay>2024-06-18T08:11:33</ie837:DateAndTimeOfValidationOfExplanationOnDelay>
+            |                  <ie837:DateAndTimeOfValidationOfExplanationOnDelay>2024-06-18T08:11:34</ie837:DateAndTimeOfValidationOfExplanationOnDelay>
             |               </ie837:Attributes>
             |               <ie837:ExciseMovement>
             |                  <ie837:AdministrativeReferenceCode>18GB00000000000232361</ie837:AdministrativeReferenceCode>
@@ -1607,7 +1607,7 @@ class GetMovementResponseSpec extends TestBaseSpec with GetMovementFixture {
             |            <urn:MessageSender>NDEA.GB</urn:MessageSender>
             |            <urn:MessageRecipient>NDEA.GB</urn:MessageRecipient>
             |            <urn:DateOfPreparation>2024-06-18</urn:DateOfPreparation>
-            |            <urn:TimeOfPreparation>07:18:54.852159</urn:TimeOfPreparation>
+            |            <urn:TimeOfPreparation>08:18:56.452159</urn:TimeOfPreparation>
             |            <urn:MessageIdentifier>GB100000000305527</urn:MessageIdentifier>
             |            <urn:CorrelationIdentifier>PORTAL07498cf951004becbc3c73c14c103b13</urn:CorrelationIdentifier>
             |         </ie837:Header>

--- a/test/uk/gov/hmrc/emcstfe/utils/DateUtilsSpec.scala
+++ b/test/uk/gov/hmrc/emcstfe/utils/DateUtilsSpec.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.emcstfe.utils
+
+import uk.gov.hmrc.emcstfe.support.TestBaseSpec
+
+import java.time.LocalTime
+
+class DateUtilsSpec extends TestBaseSpec with DateUtils {
+
+  "LocalTimeExtensions" when {
+
+    "calling .roundToNearestSecond" must {
+
+      "handle .000000 by not changing the time" in {
+        LocalTime.parse("12:01:01.000000").roundToNearestSecond() shouldBe LocalTime.of(12, 1, 1)
+      }
+
+      "handle .499999 by rounding down" in {
+        LocalTime.parse("12:01:01.499999").roundToNearestSecond() shouldBe LocalTime.of(12, 1, 1)
+      }
+
+      "handle .500000 by rounding up" in {
+        LocalTime.parse("12:01:01.500000").roundToNearestSecond() shouldBe LocalTime.of(12, 1, 2)
+      }
+
+      "handle .999999 by rounding up" in {
+        LocalTime.parse("12:01:01.999999").roundToNearestSecond() shouldBe LocalTime.of(12, 1, 2)
+      }
+    }
+  }
+}

--- a/test/uk/gov/hmrc/emcstfe/utils/LocalDateTimeXMLReaderSpec.scala
+++ b/test/uk/gov/hmrc/emcstfe/utils/LocalDateTimeXMLReaderSpec.scala
@@ -20,7 +20,7 @@ import com.lucidchart.open.xtract.{ParseFailure, ParseSuccess}
 import uk.gov.hmrc.emcstfe.support.TestBaseSpec
 import uk.gov.hmrc.emcstfe.utils.LocalDateTimeXMLReader.LocalDateTimeParseFailure
 
-import java.time.LocalDateTime
+import java.time.{LocalDate, LocalDateTime, LocalTime}
 import scala.xml.Elem
 
 class LocalDateTimeXMLReaderSpec extends TestBaseSpec {
@@ -44,6 +44,52 @@ class LocalDateTimeXMLReaderSpec extends TestBaseSpec {
         val xml: Elem = <ldt>2020-06-04T14:56:21BANGFOO</ldt>
 
         LocalDateTimeXMLReader.xmlLocalDateTimeReads.read(xml) shouldBe ParseFailure(LocalDateTimeParseFailure("Text '2020-06-04T14:56:21BANGFOO' could not be parsed, unparsed text found at index 19"))
+      }
+    }
+  }
+
+  "LocalDateXMLReader" must {
+
+    "successfully parse a LD" when {
+
+      "XML response contains a valid LocalDateTime format" in {
+
+        val xml: Elem = <ld>2020-06-04</ld>
+
+        LocalDateTimeXMLReader.xmlLocalDateReads.read(xml) shouldBe ParseSuccess(LocalDate.of(2020, 6, 4))
+      }
+    }
+
+    "fail to parse a LD" when {
+
+      "XML response is NOT a valid LocalDate format" in {
+
+        val xml: Elem = <ld>2020-06-BANGFOO</ld>
+
+        LocalDateTimeXMLReader.xmlLocalDateReads.read(xml) shouldBe ParseFailure(LocalDateTimeParseFailure("Text '2020-06-BANGFOO' could not be parsed at index 8"))
+      }
+    }
+  }
+
+  "LocalTimeXMLReader" must {
+
+    "successfully parse a LT" when {
+
+      "XML response contains a valid LocalTime format" in {
+
+        val xml: Elem = <lt>04:06:22.123456789</lt>
+
+        LocalDateTimeXMLReader.xmlLocalTimeReads.read(xml) shouldBe ParseSuccess(LocalTime.of(4, 6, 22, 123456789))
+      }
+    }
+
+    "fail to parse a LT" when {
+
+      "XML response is NOT a valid LocalTime format" in {
+
+        val xml: Elem = <lt>04:06:BANGFOO</lt>
+
+        LocalDateTimeXMLReader.xmlLocalTimeReads.read(xml) shouldBe ParseFailure(LocalDateTimeParseFailure("Text '04:06:BANGFOO' could not be parsed, unparsed text found at index 5"))
       }
     }
   }


### PR DESCRIPTION
There's no out of the box rounding mechanism for JavaTime, so this implements a small implicit def to extends the functionality of `LocalTime`

- https://github.com/hmrc/emcs-tfe-stub/pull/130