### PR TITLE
ETFE-4453 Support both EMC15B & ETDS12 pre-validate response

### DIFF
--- a/app/uk/gov/hmrc/emcstfe/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/emcstfe/config/AppConfig.scala
@@ -77,6 +77,9 @@ class AppConfig @Inject() (servicesConfig: ServicesConfig, configuration: Config
   def eisPrevalidateBearerToken: String =
     configuration.get[String]("eis.emc15b.token")
 
+  def eisPrevalidateETDS12BearerToken: String =
+    configuration.get[String]("eis.etds12.token")
+
   def eisGetMessagesUrl(): String =
     eisBaseUrl + "/emcs/messages/v1/messages"
 
@@ -100,6 +103,9 @@ class AppConfig @Inject() (servicesConfig: ServicesConfig, configuration: Config
 
   def eisPreValidateTraderUrl(): String =
     eisBaseUrl + "/emcs/pre-validate-trader/v1"
+
+  def eisPreValidateTraderViaETDS12Url(): String =
+    eisBaseUrl + "/etds/traderprevalidation/v1"
 
   def eisForwardedHost(): String = configuration.get[String]("eis.forwardedHost")
 }

--- a/app/uk/gov/hmrc/emcstfe/connectors/EisConnector.scala
+++ b/app/uk/gov/hmrc/emcstfe/connectors/EisConnector.scala
@@ -20,14 +20,14 @@ import play.api.libs.json.Reads
 import uk.gov.hmrc.emcstfe.config.AppConfig
 import uk.gov.hmrc.emcstfe.connectors.httpParsers.EisJsonHttpParser
 import uk.gov.hmrc.emcstfe.models.request._
-import uk.gov.hmrc.emcstfe.models.request.eis.preValidate.PreValidateRequest
+import uk.gov.hmrc.emcstfe.models.request.eis.preValidate.{PreValidateETDS12Request, PreValidateRequest}
 import uk.gov.hmrc.emcstfe.models.request.eis.{EisConsumptionRequest, EisSubmissionRequest}
 import uk.gov.hmrc.emcstfe.models.response._
 import uk.gov.hmrc.emcstfe.models.response.getMessages.GetMessagesResponse
 import uk.gov.hmrc.emcstfe.models.response.getMovement.GetMovementListResponse
 import uk.gov.hmrc.emcstfe.models.response.getMovementHistoryEvents.GetMovementHistoryEventsResponse
 import uk.gov.hmrc.emcstfe.models.response.getSubmissionFailureMessage.GetSubmissionFailureMessageResponse
-import uk.gov.hmrc.emcstfe.models.response.prevalidate.PreValidateTraderApiResponse
+import uk.gov.hmrc.emcstfe.models.response.prevalidate.{PreValidateTraderApiResponse, PreValidateTraderETDSResponse}
 import uk.gov.hmrc.emcstfe.services.MetricsService
 import uk.gov.hmrc.emcstfe.utils.Logging
 import uk.gov.hmrc.http.{HeaderCarrier, HttpClient}
@@ -113,5 +113,11 @@ class EisConnector @Inject()(val http: HttpClient,
                        (implicit headerCarrier: HeaderCarrier, ec: ExecutionContext, jsonReads: Reads[PreValidateTraderApiResponse]): Future[Either[ErrorResponse, PreValidateTraderApiResponse]] = {
     val url = appConfig.eisPreValidateTraderUrl()
     prepareJsonAndSubmit(url, request, "preValidateTrader", appConfig.eisPrevalidateBearerToken)
+  }
+
+  def preValidateTraderViaETDS12(request: PreValidateETDS12Request)
+                       (implicit headerCarrier: HeaderCarrier, ec: ExecutionContext, jsonReads: Reads[PreValidateTraderETDSResponse]): Future[Either[ErrorResponse, PreValidateTraderETDSResponse]] = {
+    val url = appConfig.eisPreValidateTraderViaETDS12Url()
+    prepareJsonAndSubmit(url, request, "preValidateTraderViaETDS12", appConfig.eisPrevalidateETDS12BearerToken)
   }
 }

--- a/app/uk/gov/hmrc/emcstfe/featureswitch/core/config/FeatureSwitchingModule.scala
+++ b/app/uk/gov/hmrc/emcstfe/featureswitch/core/config/FeatureSwitchingModule.scala
@@ -25,21 +25,27 @@ import javax.inject.Singleton
 @Singleton
 class FeatureSwitchingModule extends Module with FeatureSwitchRegistry {
 
-  val switches: Seq[FeatureSwitch] = Seq(UseDownstreamStub, DefaultDraftMovementCorrelationId)
+  val switches: Seq[FeatureSwitch] = Seq(UseDownstreamStub, DefaultDraftMovementCorrelationId, EnablePreValidateViaETDS12)
 
   override def bindings(environment: Environment, configuration: Configuration): Seq[Binding[_]] = {
     Seq(
       bind[FeatureSwitchRegistry].to(this).eagerly()
     )
   }
+
 }
 
 case object UseDownstreamStub extends FeatureSwitch {
-  override val configName: String = "features.downstreamStub"
+  override val configName: String  = "features.downstreamStub"
   override val displayName: String = "enables downstream stub (for EIS calls)"
 }
 
 case object DefaultDraftMovementCorrelationId extends FeatureSwitch {
-  override val configName: String = "features.defaultDraftMovementCorrelationId"
+  override val configName: String  = "features.defaultDraftMovementCorrelationId"
   override val displayName: String = "Defaults the draft movement correlation ID (local/staging only)"
+}
+
+case object EnablePreValidateViaETDS12 extends FeatureSwitch {
+  override val configName: String  = "features.enablePreValidateViaETDS12"
+  override val displayName: String = "Enables pre-validation via the ETDS12 API"
 }

--- a/app/uk/gov/hmrc/emcstfe/models/preValidate/PreValidateTraderModel.scala
+++ b/app/uk/gov/hmrc/emcstfe/models/preValidate/PreValidateTraderModel.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.emcstfe.models.preValidate
 
 import play.api.libs.json.{Format, Json}
 
-case class PreValidateTraderModel (ern: String, entityGroup: String, productCodes: Seq[String])
+case class PreValidateTraderModel (ern: String, entityGroup: Option[String], productCodes: Option[Seq[String]])
 
 object PreValidateTraderModel {
   implicit val format: Format[PreValidateTraderModel] = Json.format

--- a/app/uk/gov/hmrc/emcstfe/models/request/eis/preValidate/ExciseTraderValidationRequest.scala
+++ b/app/uk/gov/hmrc/emcstfe/models/request/eis/preValidate/ExciseTraderValidationRequest.scala
@@ -43,6 +43,16 @@ case class PreValidateRequest(exciseTraderValidationRequest: ExciseTraderValidat
   override def exciseRegistrationNumber: String = exciseTraderValidationRequest.exciseTraderRequest.exciseRegistrationNumber
 }
 
+case class PreValidateETDS12Request(exciseId: String, entityGroup: Option[String], products: Option[Seq[Product]]) extends EisSubmissionRequest {
+
+  override def metricName: String = "pre-validate-trader"
+
+  override def eisXMLBody(): String = "" // deliberate as EIS does not support XML, only JSON for pre-validate
+
+  override def toJson: JsValue = Json.toJson(this)
+
+  override def exciseRegistrationNumber: String = exciseId
+}
 
 object Product {
   implicit val format: Format[Product] = Json.format
@@ -62,4 +72,8 @@ object ExciseTraderValidationRequest {
 
 object PreValidateRequest {
   implicit val format: Format[PreValidateRequest] = Json.format
+}
+
+object PreValidateETDS12Request {
+  implicit val format: Format[PreValidateETDS12Request] = Json.format
 }

--- a/app/uk/gov/hmrc/emcstfe/models/response/prevalidate/ExciseTraderValidationResponse.scala
+++ b/app/uk/gov/hmrc/emcstfe/models/response/prevalidate/ExciseTraderValidationResponse.scala
@@ -47,6 +47,24 @@ case class ExciseTraderValidationResponse (
 
 case class PreValidateTraderApiResponse(exciseTraderValidationResponse: ExciseTraderValidationResponse)
 
+case class ETDSProductError(
+                             exciseProductCode: String,
+                             errorCode: Int,
+                             errorText: String)
+
+case class ETDSValidateProductAuthorisationResponse(productError: Option[Seq[ETDSProductError]] = None)
+
+case class ETDSFailDetails(
+                            validTrader: Boolean,
+                            errorCode: Option[Int],
+                            errorText: Option[String],
+                            validateProductAuthorisationResponse: Option[ETDSValidateProductAuthorisationResponse])
+
+case class PreValidateTraderETDSResponse(
+                                          processingDateTime: String,
+                                          exciseId: String,
+                                          validationResult: String,
+                                          failDetails: Option[ETDSFailDetails])
 
 object ProductError {
   implicit val format: Format[ProductError] = Json.format
@@ -66,4 +84,20 @@ object ExciseTraderValidationResponse {
 
 object PreValidateTraderApiResponse {
   implicit val format: Format[PreValidateTraderApiResponse] = Json.format
+}
+
+object ETDSProductError {
+  implicit val format: Format[ETDSProductError] = Json.format
+}
+
+object ETDSValidateProductAuthorisationResponse {
+  implicit val format: Format[ETDSValidateProductAuthorisationResponse] = Json.format
+}
+
+object ETDSFailDetails {
+  implicit val format: Format[ETDSFailDetails] = Json.format
+}
+
+object PreValidateTraderETDSResponse {
+  implicit val format: Format[PreValidateTraderETDSResponse] = Json.format
 }

--- a/app/uk/gov/hmrc/emcstfe/services/PreValidateTraderService.scala
+++ b/app/uk/gov/hmrc/emcstfe/services/PreValidateTraderService.scala
@@ -18,10 +18,11 @@ package uk.gov.hmrc.emcstfe.services
 
 import uk.gov.hmrc.emcstfe.config.AppConfig
 import uk.gov.hmrc.emcstfe.connectors.EisConnector
+import uk.gov.hmrc.emcstfe.featureswitch.core.config.{EnablePreValidateViaETDS12, FeatureSwitching}
 import uk.gov.hmrc.emcstfe.models.preValidate.PreValidateTraderModel
 import uk.gov.hmrc.emcstfe.models.request.eis.preValidate._
 import uk.gov.hmrc.emcstfe.models.response.ErrorResponse
-import uk.gov.hmrc.emcstfe.models.response.prevalidate.PreValidateTraderApiResponse
+import uk.gov.hmrc.emcstfe.models.response.prevalidate._
 import uk.gov.hmrc.emcstfe.utils.Logging
 import uk.gov.hmrc.http.HeaderCarrier
 
@@ -29,22 +30,64 @@ import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
-class PreValidateTraderService @Inject()(eisConnector: EisConnector, val config: AppConfig) extends Logging {
+class PreValidateTraderService @Inject() (eisConnector: EisConnector, val config: AppConfig) extends Logging with FeatureSwitching {
 
-  def preValidateTrader(preValidateTraderRequest: PreValidateTraderModel)
-                       (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Either[ErrorResponse, PreValidateTraderApiResponse]] = {
+  def preValidateTrader(preValidateTraderRequest: PreValidateTraderModel)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Either[ErrorResponse, PreValidateTraderETDSResponse]] = {
 
-    val request = PreValidateRequest(
-      exciseTraderValidationRequest = ExciseTraderValidationRequest(
-        exciseTraderRequest = ExciseTraderRequest(
-          exciseRegistrationNumber = preValidateTraderRequest.ern,
-          entityGroup = preValidateTraderRequest.entityGroup,
-          validateProductAuthorisationRequest = preValidateTraderRequest.productCodes.map(code => ValidateProductAuthorisationRequest(Product(code)))
+    if (isEnabled(EnablePreValidateViaETDS12)) {
+      val request = PreValidateETDS12Request(
+        preValidateTraderRequest.ern,
+        preValidateTraderRequest.entityGroup,
+        preValidateTraderRequest.productCodes.map(_.map(Product.apply))
+      )
+
+      eisConnector.preValidateTraderViaETDS12(request)
+    } else {
+      val request = PreValidateRequest(
+        exciseTraderValidationRequest = ExciseTraderValidationRequest(
+          ExciseTraderRequest(
+            preValidateTraderRequest.ern,
+            preValidateTraderRequest.entityGroup.getOrElse("UK Record"),
+            preValidateTraderRequest.productCodes.map(_.map(productCode => ValidateProductAuthorisationRequest(Product(productCode)))).getOrElse(Seq.empty)
+          )
         )
       )
+
+      eisConnector.preValidateTrader(request).map {
+        case Left(error)     => Left(error)
+        case Right(response) => Right(convertTo(response))
+      }
+    }
+  }
+
+  def convertTo(response: PreValidateTraderApiResponse): PreValidateTraderETDSResponse = {
+    val exciseTraderResponse = response.exciseTraderValidationResponse.exciseTraderResponse.head
+
+    val containsProductErrors = exciseTraderResponse.validateProductAuthorisationResponse.exists(_.productError.exists(_.nonEmpty))
+
+    PreValidateTraderETDSResponse(
+      processingDateTime = response.exciseTraderValidationResponse.validationTimestamp,
+      exciseId = exciseTraderResponse.exciseRegistrationNumber,
+      validationResult = if (exciseTraderResponse.validTrader && !containsProductErrors) "Pass" else "Fail",
+      failDetails = exciseTraderResponse.validateProductAuthorisationResponse.flatMap(_.productError).map { productError =>
+        ETDSFailDetails(
+          validTrader = exciseTraderResponse.validTrader,
+          errorCode = exciseTraderResponse.errorCode.map(_.toInt),
+          errorText = exciseTraderResponse.errorText,
+          validateProductAuthorisationResponse = Some(
+            ETDSValidateProductAuthorisationResponse(
+              productError = Some(productError.map { error =>
+                ETDSProductError(
+                  exciseProductCode = error.exciseProductCode,
+                  errorCode = error.errorCode.toInt,
+                  errorText = error.errorText
+                )
+              })
+            ))
+        )
+      }
     )
 
-    eisConnector.preValidateTrader(request)
   }
 
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -125,6 +125,7 @@ microservice {
 features {
   downstreamStub = false
   defaultDraftMovementCorrelationId = true
+  enablePreValidateViaETDS12 = false
 }
 
 eis {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -134,4 +134,5 @@ eis {
   emcmes.token = "value-messages"
   emcmov.token = "value-movements"
   emc15b.token = "value-prevalidate"
+  etds12.token = "value-prevalidate-etds12"
 }

--- a/test/uk/gov/hmrc/emcstfe/config/AppConfigSpec.scala
+++ b/test/uk/gov/hmrc/emcstfe/config/AppConfigSpec.scala
@@ -63,6 +63,9 @@ class AppConfigSpec extends TestBaseSpec with FeatureSwitching {
       "return the correct value for eis.emc15b.token" in {
         config.eisPrevalidateBearerToken shouldBe "value-prevalidate"
       }
+      "return the correct value for eis.etds12.token" in {
+        config.eisPrevalidateETDS12BearerToken shouldBe "value-prevalidate-etds12"
+      }
     }
   }
 

--- a/test/uk/gov/hmrc/emcstfe/controllers/PreValidateTraderControllerSpec.scala
+++ b/test/uk/gov/hmrc/emcstfe/controllers/PreValidateTraderControllerSpec.scala
@@ -42,12 +42,12 @@ class PreValidateTraderControllerSpec extends TestBaseSpec with FakeAuthAction w
       s"return ${Status.OK} (OK)" when {
         "service returns a Right" in new Fixture(FakeSuccessAuthAction) {
 
-          MockService.preValidateTrader(preValidateTraderModelRequest).returns(Future.successful(Right(preValidateApiResponseModel)))
+          MockService.preValidateTrader(preValidateTraderModelRequest).returns(Future.successful(Right(preValidateEtds12ApiResponseModel)))
 
           val result = controller.submit(testErn)(fakeRequest)
 
           status(result) shouldBe Status.OK
-          contentAsJson(result) shouldBe preValidateApiResponseAsJson
+          contentAsJson(result) shouldBe preValidateEtds12ApiResponseAsJson
         }
       }
 

--- a/test/uk/gov/hmrc/emcstfe/fixtures/PreValidateFixtures.scala
+++ b/test/uk/gov/hmrc/emcstfe/fixtures/PreValidateFixtures.scala
@@ -19,17 +19,17 @@ package uk.gov.hmrc.emcstfe.fixtures
 import play.api.libs.json.{JsValue, Json}
 import uk.gov.hmrc.emcstfe.models.preValidate.PreValidateTraderModel
 import uk.gov.hmrc.emcstfe.models.request.eis.preValidate._
-import uk.gov.hmrc.emcstfe.models.response.prevalidate.PreValidateTraderApiResponse
+import uk.gov.hmrc.emcstfe.models.response.prevalidate.{PreValidateTraderApiResponse, PreValidateTraderETDSResponse}
 
 trait PreValidateFixtures extends BaseFixtures {
 
   val preValidateTraderModelRequest = PreValidateTraderModel(
     ern = testErn,
-    entityGroup = "UK Record",
-    productCodes = Seq("W200", "S200", "W300")
+    entityGroup = Some("UK Record"),
+    productCodes = Some(Seq("W200", "S200", "W300"))
   )
 
-  val preValidateApiRequestModel = PreValidateRequest(
+  val preValidateEmc15bApiRequestModel = PreValidateRequest(
     exciseTraderValidationRequest = ExciseTraderValidationRequest(
       exciseTraderRequest = ExciseTraderRequest(
         exciseRegistrationNumber = testErn,
@@ -49,8 +49,7 @@ trait PreValidateFixtures extends BaseFixtures {
     )
   )
 
-  val preValidateApiResponseAsJson: JsValue = Json.parse(
-    s"""
+  val preValidateEmc15bApiResponseAsJson: JsValue = Json.parse(s"""
     | {
     |   "exciseTraderValidationResponse": {
     |     "validationTimestamp": "2023-12-15T10:55:17.443Z",
@@ -69,6 +68,28 @@ trait PreValidateFixtures extends BaseFixtures {
     | }
     |""".stripMargin)
 
-  val preValidateApiResponseModel = preValidateApiResponseAsJson.as[PreValidateTraderApiResponse]
+  val preValidateEmc15bApiResponseModel = preValidateEmc15bApiResponseAsJson.as[PreValidateTraderApiResponse]
 
+  val preValidateEtds12ApiRequestModel = PreValidateETDS12Request(
+    exciseId = testErn,
+    entityGroup = Some("UK Record"),
+    products = Some(
+      Seq(
+        Product(exciseProductCode = "W200"),
+        Product(exciseProductCode = "S200"),
+        Product(exciseProductCode = "W300")
+      ))
+  )
+
+  val preValidateEtds12ApiResponseAsJson: JsValue = Json.parse(
+    s"""
+       | {
+       |  "processingDateTime": "2023-12-15T10:55:17.443Z",
+       |  "exciseId": "GBWK002281023",
+       |  "validationResult": "Pass"
+       | }
+       |""".stripMargin
+  )
+
+  val preValidateEtds12ApiResponseModel = preValidateEtds12ApiResponseAsJson.as[PreValidateTraderETDSResponse]
 }

--- a/test/uk/gov/hmrc/emcstfe/mocks/connectors/MockEisConnector.scala
+++ b/test/uk/gov/hmrc/emcstfe/mocks/connectors/MockEisConnector.scala
@@ -22,13 +22,13 @@ import play.api.libs.json.Reads
 import uk.gov.hmrc.emcstfe.connectors.EisConnector
 import uk.gov.hmrc.emcstfe.models.request._
 import uk.gov.hmrc.emcstfe.models.request.eis.EisSubmissionRequest
-import uk.gov.hmrc.emcstfe.models.request.eis.preValidate.PreValidateRequest
+import uk.gov.hmrc.emcstfe.models.request.eis.preValidate.{PreValidateETDS12Request, PreValidateRequest}
 import uk.gov.hmrc.emcstfe.models.response._
 import uk.gov.hmrc.emcstfe.models.response.getMessages.GetMessagesResponse
 import uk.gov.hmrc.emcstfe.models.response.getMovement.GetMovementListResponse
 import uk.gov.hmrc.emcstfe.models.response.getMovementHistoryEvents.GetMovementHistoryEventsResponse
 import uk.gov.hmrc.emcstfe.models.response.getSubmissionFailureMessage.GetSubmissionFailureMessageResponse
-import uk.gov.hmrc.emcstfe.models.response.prevalidate.PreValidateTraderApiResponse
+import uk.gov.hmrc.emcstfe.models.response.prevalidate.{PreValidateTraderApiResponse, PreValidateTraderETDSResponse}
 import uk.gov.hmrc.http.HeaderCarrier
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -89,5 +89,9 @@ trait MockEisConnector extends MockFactory {
         .expects(request, *, *, *)
     }
 
+    def preValidateTraderViaETDS12(request: PreValidateETDS12Request): CallHandler4[PreValidateETDS12Request, HeaderCarrier, ExecutionContext, Reads[PreValidateTraderETDSResponse], Future[Either[ErrorResponse, PreValidateTraderETDSResponse]]] = {
+      (mockEisConnector.preValidateTraderViaETDS12(_: PreValidateETDS12Request)(_: HeaderCarrier, _: ExecutionContext, _: Reads[PreValidateTraderETDSResponse]))
+        .expects(request, *, *, *)
+    }
   }
 }

--- a/test/uk/gov/hmrc/emcstfe/mocks/services/MockPreValidateTraderService.scala
+++ b/test/uk/gov/hmrc/emcstfe/mocks/services/MockPreValidateTraderService.scala
@@ -21,7 +21,7 @@ import org.scalamock.scalatest.MockFactory
 import org.scalatest.matchers.should.Matchers
 import uk.gov.hmrc.emcstfe.models.preValidate.PreValidateTraderModel
 import uk.gov.hmrc.emcstfe.models.response.ErrorResponse
-import uk.gov.hmrc.emcstfe.models.response.prevalidate.PreValidateTraderApiResponse
+import uk.gov.hmrc.emcstfe.models.response.prevalidate.PreValidateTraderETDSResponse
 import uk.gov.hmrc.emcstfe.services.PreValidateTraderService
 import uk.gov.hmrc.http.HeaderCarrier
 
@@ -33,7 +33,7 @@ trait MockPreValidateTraderService extends MockFactory {
 
   object MockService extends Matchers {
 
-    def preValidateTrader(preValidateTraderRequest: PreValidateTraderModel): CallHandler3[PreValidateTraderModel, HeaderCarrier, ExecutionContext, Future[Either[ErrorResponse, PreValidateTraderApiResponse]]] =
+    def preValidateTrader(preValidateTraderRequest: PreValidateTraderModel): CallHandler3[PreValidateTraderModel, HeaderCarrier, ExecutionContext, Future[Either[ErrorResponse, PreValidateTraderETDSResponse]]] =
         (mockService.preValidateTrader(_: PreValidateTraderModel)(_: HeaderCarrier, _: ExecutionContext)).expects(preValidateTraderRequest, *, *)
 
   }


### PR DESCRIPTION
- Feature toggle for switching between the existing EMC15B API response and the new ETDS12 API response
- Changes have been made within emcs-tfe-frontend to cater only for the ETDS12 API response (emcs-tfe maps the existing EMC15B response to a ETDS12 response) - https://github.com/hmrc/emcs-tfe-frontend/pull/231