### PR TITLE
[ETFE-4527] add endpoint to call emcs-tfe-reference-data

### DIFF
--- a/app/uk/gov/hmrc/emcstfe/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/emcstfe/config/AppConfig.scala
@@ -32,6 +32,9 @@ class AppConfig @Inject() (servicesConfig: ServicesConfig, configuration: Config
 
   def eisUrl: String = servicesConfig.baseUrl("eis")
 
+  def knownFactsCandEUrl(ern: String): String =
+    servicesConfig.baseUrl("emcs-tfe-reference-data") + s"/emcs-tfe-reference-data/oracle/trader-known-facts?exciseRegistrationId=$ern"
+
   def createMovementUserAnswersTTL(): Duration           = Duration(configuration.get[String]("mongodb.createMovementUserAnswers.TTL"))
   def createMovementUserAnswersReplaceIndexes(): Boolean = configuration.get[Boolean]("mongodb.createMovementUserAnswers.replaceIndexes")
 

--- a/app/uk/gov/hmrc/emcstfe/connectors/TraderKnownFactsConnector.scala
+++ b/app/uk/gov/hmrc/emcstfe/connectors/TraderKnownFactsConnector.scala
@@ -27,7 +27,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class TraderKnownFactsConnector @Inject() (val http: HttpClient, appConfig: AppConfig) extends TraderKnownFactsHttpParser with Logging {
 
-  def getTraderKnownFacts(ern: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Either[ErrorResponse, TraderKnownFacts]] =
+  def getTraderKnownFacts(ern: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Either[ErrorResponse, Option[TraderKnownFacts]]] =
     http.GET(appConfig.knownFactsCandEUrl(ern))(modelFromJsonHttpReads, hc, ec)
 
 }

--- a/app/uk/gov/hmrc/emcstfe/connectors/TraderKnownFactsConnector.scala
+++ b/app/uk/gov/hmrc/emcstfe/connectors/TraderKnownFactsConnector.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.emcstfe.connectors
+
+import com.google.inject.Inject
+import uk.gov.hmrc.emcstfe.config.AppConfig
+import uk.gov.hmrc.emcstfe.connectors.httpParsers.TraderKnownFactsHttpParser
+import uk.gov.hmrc.emcstfe.models.response.{ErrorResponse, TraderKnownFacts}
+import uk.gov.hmrc.emcstfe.utils.Logging
+import uk.gov.hmrc.http.{HeaderCarrier, HttpClient}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class TraderKnownFactsConnector @Inject() (val http: HttpClient, appConfig: AppConfig) extends TraderKnownFactsHttpParser with Logging {
+
+  def getTraderKnownFacts(ern: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Either[ErrorResponse, TraderKnownFacts]] =
+    http.GET(appConfig.knownFactsCandEUrl(ern))(modelFromJsonHttpReads, hc, ec)
+
+}

--- a/app/uk/gov/hmrc/emcstfe/connectors/httpParsers/TraderKnownFactsHttpParser.scala
+++ b/app/uk/gov/hmrc/emcstfe/connectors/httpParsers/TraderKnownFactsHttpParser.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.emcstfe.connectors.httpParsers
+
+import play.api.LoggerLike
+import play.api.http.Status.OK
+import play.api.libs.json.{JsonValidationError, Reads}
+import uk.gov.hmrc.emcstfe.models.response.{ErrorResponse, TraderKnownFacts}
+import uk.gov.hmrc.emcstfe.models.response.ErrorResponse.{TraderKnownFactsParsingError, UnexpectedDownstreamResponseError}
+import uk.gov.hmrc.http.{HttpReads, HttpResponse}
+
+import scala.util.{Failure, Success, Try}
+
+trait TraderKnownFactsHttpParser {
+  val logger: LoggerLike
+
+  def modelFromJsonHttpReads(implicit jsonReads: Reads[TraderKnownFacts]): HttpReads[Either[ErrorResponse, TraderKnownFacts]] = (_: String, _: String, response: HttpResponse) => {
+    response.status match {
+      case OK => Try {
+        jsonReads.reads(response.json).fold(
+          errors => Left(TraderKnownFactsParsingError(errors.flatMap(_._2).toSeq)),
+          Right(_)
+        )
+      } match {
+        case Failure(exception) =>
+          logger.error(exception.getMessage, exception)
+          Left(TraderKnownFactsParsingError(Seq(JsonValidationError(exception.getMessage))))
+        case Success(value) => value
+      }
+      case _ =>
+        logger.warn(s"[modelFromJsonHttpReads] Received unexpected status: ${response.status}")
+        logger.debug(s"[modelFromJsonHttpReads] Error response body: ${response.body}")
+        Left(UnexpectedDownstreamResponseError)
+    }
+  }
+}

--- a/app/uk/gov/hmrc/emcstfe/controllers/TraderKnownFactsController.scala
+++ b/app/uk/gov/hmrc/emcstfe/controllers/TraderKnownFactsController.scala
@@ -29,8 +29,9 @@ class TraderKnownFactsController @Inject() (cc: ControllerComponents, service: T
 
   def getTraderKnownFacts(exciseRegistrationId: String): Action[AnyContent] = authorisedUserRequest(exciseRegistrationId) { implicit request =>
     service.getTraderKnownFacts(exciseRegistrationId).map {
-      case Left(value)  => InternalServerError(Json.toJson(value))
-      case Right(value) => Ok(Json.toJson(value))
+      case Left(value)        => InternalServerError(Json.toJson(value))
+      case Right(None)        => NoContent
+      case Right(Some(value)) => Ok(Json.toJson(value))
     }
   }
 

--- a/app/uk/gov/hmrc/emcstfe/controllers/TraderKnownFactsController.scala
+++ b/app/uk/gov/hmrc/emcstfe/controllers/TraderKnownFactsController.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.emcstfe.controllers
+
+import play.api.libs.json.Json
+import play.api.mvc.{Action, AnyContent, ControllerComponents}
+import uk.gov.hmrc.emcstfe.controllers.actions.{AuthAction, AuthActionHelper}
+import uk.gov.hmrc.emcstfe.services.TraderKnownFactsService
+import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
+
+import javax.inject.Inject
+import scala.concurrent.ExecutionContext
+
+class TraderKnownFactsController @Inject() (cc: ControllerComponents, service: TraderKnownFactsService, override val auth: AuthAction)(implicit ec: ExecutionContext) extends BackendController(cc) with AuthActionHelper {
+
+  def getTraderKnownFacts(exciseRegistrationId: String): Action[AnyContent] = authorisedUserRequest(exciseRegistrationId) { implicit request =>
+    service.getTraderKnownFacts(exciseRegistrationId).map {
+      case Left(value)  => InternalServerError(Json.toJson(value))
+      case Right(value) => Ok(Json.toJson(value))
+    }
+  }
+
+}

--- a/app/uk/gov/hmrc/emcstfe/models/response/ErrorResponse.scala
+++ b/app/uk/gov/hmrc/emcstfe/models/response/ErrorResponse.scala
@@ -45,6 +45,10 @@ object ErrorResponse {
     val message = s"Error from Mongo with message: $msg"
   }
 
+  case class TraderKnownFactsParsingError(errors: Seq[JsonValidationError]) extends ErrorResponse {
+    val message = s"Errors parsing JSON, errors: $errors"
+  }
+
   case class EISJsonParsingError(errors: Seq[JsonValidationError]) extends ErrorResponse {
     val message = s"Errors parsing JSON, errors: $errors"
   }
@@ -79,16 +83,6 @@ object ErrorResponse {
 
   case class QueryParameterError(queryParams: Seq[(String, String)]) extends ErrorResponse {
     val message = s"Invalid query parameters provided. Query parameters: $queryParams"
-  }
-
-  case class InvalidLegacyRequestProvided(message: String) extends ErrorResponse
-
-  case class InvalidLegacyActionProvided(action: String) extends ErrorResponse {
-    val message = s"Unknown action requested for legacy: $action"
-  }
-
-  case object NoLegacyActionProvided extends ErrorResponse {
-    val message = s"no action found in the request"
   }
 
   case class TemplateDoesNotExist(templateId: String) extends ErrorResponse {

--- a/app/uk/gov/hmrc/emcstfe/models/response/TraderKnownFacts.scala
+++ b/app/uk/gov/hmrc/emcstfe/models/response/TraderKnownFacts.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/emcstfe/models/response/TraderKnownFacts.scala
+++ b/app/uk/gov/hmrc/emcstfe/models/response/TraderKnownFacts.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.emcstfe.models.response
+
+import play.api.libs.functional.syntax._
+import play.api.libs.json._
+
+case class TraderKnownFacts(traderName: String, addressLine1: Option[String], addressLine2: Option[String], addressLine3: Option[String], addressLine4: Option[String], addressLine5: Option[String], postcode: Option[String])
+
+object TraderKnownFacts {
+  implicit val reads: Reads[TraderKnownFacts] = (
+    ((__ \ "traderName").read[String] or (__ \ "businessName").read[String]) and
+      (__ \ "addressLine1").readNullable[String] and
+      (__ \ "addressLine2").readNullable[String] and
+      (__ \ "addressLine3").readNullable[String] and
+      (__ \ "addressLine4").readNullable[String] and
+      (__ \ "addressLine5").readNullable[String] and
+      ((__ \ "postcode").read[String].map(Some(_)) or (__ \ "postCode").readNullable[String])
+    )(TraderKnownFacts.apply _)
+
+    implicit val writes: OWrites[TraderKnownFacts] = Json.writes[TraderKnownFacts]
+}

--- a/app/uk/gov/hmrc/emcstfe/services/TraderKnownFactsService.scala
+++ b/app/uk/gov/hmrc/emcstfe/services/TraderKnownFactsService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/emcstfe/services/TraderKnownFactsService.scala
+++ b/app/uk/gov/hmrc/emcstfe/services/TraderKnownFactsService.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.emcstfe.services
+
+import uk.gov.hmrc.emcstfe.connectors.TraderKnownFactsConnector
+import uk.gov.hmrc.emcstfe.models.response.{ErrorResponse, TraderKnownFacts}
+import uk.gov.hmrc.http.HeaderCarrier
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class TraderKnownFactsService @Inject()(connector: TraderKnownFactsConnector) {
+
+  def getTraderKnownFacts(ern: String)
+                     (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Either[ErrorResponse, TraderKnownFacts]] =
+    connector.getTraderKnownFacts(ern)
+}

--- a/app/uk/gov/hmrc/emcstfe/services/TraderKnownFactsService.scala
+++ b/app/uk/gov/hmrc/emcstfe/services/TraderKnownFactsService.scala
@@ -27,6 +27,6 @@ import scala.concurrent.{ExecutionContext, Future}
 class TraderKnownFactsService @Inject()(connector: TraderKnownFactsConnector) {
 
   def getTraderKnownFacts(ern: String)
-                     (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Either[ErrorResponse, TraderKnownFacts]] =
+                     (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Either[ErrorResponse, Option[TraderKnownFacts]]] =
     connector.getTraderKnownFacts(ern)
 }

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -22,6 +22,9 @@ POST          /create-movement/:ern/:draftId                     uk.gov.hmrc.emc
 # Pre validate trader
 POST          /pre-validate-trader/:ern                          uk.gov.hmrc.emcstfe.controllers.PreValidateTraderController.submit(ern)
 
+# Trader known facts
+GET           /trader-known-facts                                uk.gov.hmrc.emcstfe.controllers.TraderKnownFactsController.getTraderKnownFacts(exciseRegistrationId)
+
 # User answers
 ->            /user-answers                                      userAnswers.Routes
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -114,6 +114,12 @@ microservice {
       port = 8308
     }
 
+    emcs-tfe-reference-data {
+      protocol = http
+      host = localhost
+      port = 8312
+    }
+
     downstream-stub {
       protocol = http
       host = localhost

--- a/it/uk/gov/hmrc/emcstfe/controllers/TraderKnownFactsIntegrationSpec.scala
+++ b/it/uk/gov/hmrc/emcstfe/controllers/TraderKnownFactsIntegrationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/it/uk/gov/hmrc/emcstfe/controllers/TraderKnownFactsIntegrationSpec.scala
+++ b/it/uk/gov/hmrc/emcstfe/controllers/TraderKnownFactsIntegrationSpec.scala
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.emcstfe.controllers
+
+import com.github.tomakehurst.wiremock.stubbing.StubMapping
+import play.api.http.Status
+import play.api.http.Status.FORBIDDEN
+import play.api.libs.json.Json
+import play.api.libs.ws.{WSRequest, WSResponse}
+import uk.gov.hmrc.emcstfe.fixtures.TraderKnownFactsFixtures
+import uk.gov.hmrc.emcstfe.models.response.ErrorResponse._
+import uk.gov.hmrc.emcstfe.stubs.{AuthStub, DownstreamStub}
+import uk.gov.hmrc.emcstfe.support.IntegrationBaseSpec
+
+class TraderKnownFactsIntegrationSpec extends IntegrationBaseSpec with TraderKnownFactsFixtures {
+
+  private trait Test {
+    def setupStubs(): StubMapping
+
+    def uri: String = s"/trader-known-facts"
+
+    def emcsTfeReferenceDataUrl: String = s"/emcs-tfe-reference-data/oracle/trader-known-facts"
+
+    def downstreamQueryParams: Map[String, String] = Map(
+      "exciseRegistrationId" -> testErn
+    )
+
+    def request(): WSRequest = {
+      setupStubs()
+      buildRequest(uri).withQueryStringParameters("exciseRegistrationId" -> testErn)
+    }
+
+  }
+
+  "Calling the get trader known facts endpoint" when {
+
+    "user is unauthorised" must {
+      s"return FORBIDDEN ($FORBIDDEN)" in new Test {
+        override def setupStubs(): StubMapping = {
+          AuthStub.unauthorised()
+        }
+
+        val response: WSResponse = await(request().get())
+        response.status shouldBe FORBIDDEN
+      }
+    }
+
+    "user is authorised" when {
+
+      "return forbidden" when {
+        "the ERN requested does not match the ERN of the credential" in new Test {
+          override def setupStubs(): StubMapping = {
+            AuthStub.authorised("WrongERN")
+          }
+
+          val response: WSResponse = await(request().get())
+          response.status shouldBe Status.FORBIDDEN
+        }
+      }
+
+      "return a success" when {
+        "all downstream calls are successful" in new Test {
+          override def setupStubs(): StubMapping = {
+            AuthStub.authorised()
+            DownstreamStub.onSuccess(DownstreamStub.GET, emcsTfeReferenceDataUrl, downstreamQueryParams, Status.OK, Json.parse(traderKnownFactsCandEJson))
+          }
+
+          val response: WSResponse = await(request().get())
+          response.status shouldBe Status.OK
+          response.header("Content-Type") shouldBe Some("application/json")
+          response.json shouldBe Json.parse(testTraderKnownFactsJson)
+        }
+        "return an error" when {
+          "downstream call returns an unexpected HTTP response" in new Test {
+            override def setupStubs(): StubMapping = {
+              AuthStub.authorised()
+              DownstreamStub.onSuccess(DownstreamStub.GET, emcsTfeReferenceDataUrl, downstreamQueryParams, Status.NO_CONTENT, Json.obj())
+            }
+
+            val response: WSResponse = await(request().get())
+            response.status shouldBe Status.INTERNAL_SERVER_ERROR
+            response.header("Content-Type") shouldBe Some("application/json")
+            response.json shouldBe Json.toJson(UnexpectedDownstreamResponseError)
+          }
+        }
+      }
+    }
+  }
+
+}

--- a/it/uk/gov/hmrc/emcstfe/controllers/TraderKnownFactsIntegrationSpec.scala
+++ b/it/uk/gov/hmrc/emcstfe/controllers/TraderKnownFactsIntegrationSpec.scala
@@ -84,11 +84,21 @@ class TraderKnownFactsIntegrationSpec extends IntegrationBaseSpec with TraderKno
           response.header("Content-Type") shouldBe Some("application/json")
           response.json shouldBe Json.parse(testTraderKnownFactsJson)
         }
+        "downstream returns a 204" in new Test {
+          override def setupStubs(): StubMapping = {
+            AuthStub.authorised()
+            DownstreamStub.onSuccess(DownstreamStub.GET, emcsTfeReferenceDataUrl, downstreamQueryParams, Status.NO_CONTENT, Json.obj())
+          }
+
+          val response: WSResponse = await(request().get())
+          response.status shouldBe Status.NO_CONTENT
+        }
+      }
         "return an error" when {
           "downstream call returns an unexpected HTTP response" in new Test {
             override def setupStubs(): StubMapping = {
               AuthStub.authorised()
-              DownstreamStub.onSuccess(DownstreamStub.GET, emcsTfeReferenceDataUrl, downstreamQueryParams, Status.NO_CONTENT, Json.obj())
+              DownstreamStub.onSuccess(DownstreamStub.GET, emcsTfeReferenceDataUrl, downstreamQueryParams, Status.INTERNAL_SERVER_ERROR, Json.obj())
             }
 
             val response: WSResponse = await(request().get())
@@ -98,7 +108,6 @@ class TraderKnownFactsIntegrationSpec extends IntegrationBaseSpec with TraderKno
           }
         }
       }
-    }
   }
 
 }

--- a/it/uk/gov/hmrc/emcstfe/support/IntegrationBaseSpec.scala
+++ b/it/uk/gov/hmrc/emcstfe/support/IntegrationBaseSpec.scala
@@ -41,6 +41,7 @@ trait IntegrationBaseSpec
   def servicesConfig: Map[String, _] = Map(
     "microservice.services.auth.port" -> WireMockHelper.wireMockPort,
     "microservice.services.eis.port" -> WireMockHelper.wireMockPort,
+    "microservice.services.emcs-tfe-reference-data.port" -> WireMockHelper.wireMockPort,
     "auditing.consumer.baseUri.port" -> WireMockHelper.wireMockPort,
     "play.http.router" -> "testOnlyDoNotUseInAppConf.Routes",
     "createMovementUserAnswers.TTL" -> testTtl,

--- a/test/uk/gov/hmrc/emcstfe/connectors/EisConnectorSpec.scala
+++ b/test/uk/gov/hmrc/emcstfe/connectors/EisConnectorSpec.scala
@@ -17,12 +17,10 @@
 package uk.gov.hmrc.emcstfe.connectors
 
 import org.scalatest.BeforeAndAfterEach
-import play.api.http.{HeaderNames, MimeTypes, Status}
 import play.api.libs.json.JsonValidationError
 import uk.gov.hmrc.emcstfe.config.AppConfig
 import uk.gov.hmrc.emcstfe.featureswitch.core.config.{FeatureSwitching, UseDownstreamStub}
 import uk.gov.hmrc.emcstfe.fixtures._
-import uk.gov.hmrc.emcstfe.mocks.config.MockAppConfig
 import uk.gov.hmrc.emcstfe.mocks.connectors.MockHttpClient
 import uk.gov.hmrc.emcstfe.mocks.services.MockMetricsService
 import uk.gov.hmrc.emcstfe.models.request._
@@ -38,10 +36,6 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class EisConnectorSpec
     extends TestBaseSpec
-    with Status
-    with MimeTypes
-    with HeaderNames
-    with MockAppConfig
     with MockHttpClient
     with FeatureSwitching
     with BeforeAndAfterEach

--- a/test/uk/gov/hmrc/emcstfe/connectors/TraderKnownFactsConnectorSpec.scala
+++ b/test/uk/gov/hmrc/emcstfe/connectors/TraderKnownFactsConnectorSpec.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.emcstfe.connectors
+
+import org.scalatest.BeforeAndAfterEach
+import play.api.http.{HeaderNames, MimeTypes, Status}
+import uk.gov.hmrc.emcstfe.config.AppConfig
+import uk.gov.hmrc.emcstfe.featureswitch.core.config.FeatureSwitching
+import uk.gov.hmrc.emcstfe.fixtures.TraderKnownFactsFixtures
+import uk.gov.hmrc.emcstfe.mocks.connectors.MockHttpClient
+import uk.gov.hmrc.emcstfe.models.response.ErrorResponse.UnexpectedDownstreamResponseError
+import uk.gov.hmrc.emcstfe.support.UnitSpec
+
+import scala.concurrent.Future
+
+class TraderKnownFactsConnectorSpec extends UnitSpec
+  with Status
+  with MimeTypes
+  with HeaderNames
+  with MockHttpClient
+  with FeatureSwitching
+  with BeforeAndAfterEach
+  with TraderKnownFactsFixtures {
+
+  lazy val config: AppConfig = app.injector.instanceOf[AppConfig]
+
+  override def afterEach(): Unit = {
+    super.afterEach()
+  }
+
+  val connector = new TraderKnownFactsConnector(mockHttpClient, config)
+
+  "getTraderKnownFacts" should {
+    "return Right[TraderKnownFacts]" when {
+      "the http client response returns Right[TraderKnownFacts]" in {
+        val ern = "1234567890"
+
+        MockHttpClient.get(config.knownFactsCandEUrl(ern)).returns(Future.successful(Right(testTraderKnownFactsModel)))
+
+        val result = await(connector.getTraderKnownFacts(ern))
+
+        result shouldBe Right(testTraderKnownFactsModel)
+      }
+    }
+
+    "return Left[ErrorResponse]" when {
+      "the http client response returns Left[ErrorResponse]" in {
+        val ern = "1234567890"
+
+        MockHttpClient.get(config.knownFactsCandEUrl(ern)).returns(Future.successful(Left(UnexpectedDownstreamResponseError)))
+
+        val result = await(connector.getTraderKnownFacts(ern))
+
+        result shouldBe Left(UnexpectedDownstreamResponseError)
+      }
+    }
+  }
+
+}

--- a/test/uk/gov/hmrc/emcstfe/connectors/httpParsers/TraderKnownFactsHttpParserSpec.scala
+++ b/test/uk/gov/hmrc/emcstfe/connectors/httpParsers/TraderKnownFactsHttpParserSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/emcstfe/connectors/httpParsers/TraderKnownFactsHttpParserSpec.scala
+++ b/test/uk/gov/hmrc/emcstfe/connectors/httpParsers/TraderKnownFactsHttpParserSpec.scala
@@ -34,11 +34,10 @@ class TraderKnownFactsHttpParserSpec extends TestBaseSpec with TraderKnownFactsF
     override val logger: LoggerLike = _logger
   }
 
-  ".modelFromJsonHttpReads" when {
+  ".modelFromJsonHttpReads" must {
 
-    s"an OK ($OK) response is received" must {
-
-      "return a Right" when {
+    "return a Right" when {
+      s"an OK ($OK) response is received" when {
 
         "it contains valid Json" in {
 
@@ -46,9 +45,21 @@ class TraderKnownFactsHttpParserSpec extends TestBaseSpec with TraderKnownFactsF
 
           val result = TestParser.modelFromJsonHttpReads.read("GET", "/foo/bar", response)
 
-          result shouldBe Right(testTraderKnownFactsModel)
+          result shouldBe Right(Some(testTraderKnownFactsModel))
         }
       }
+      s"a NO_CONTENT ($NO_CONTENT) response is received" when {
+
+        "it contains valid Json" in {
+
+          val response = HttpResponse(NO_CONTENT, json = Json.obj(), headers = Map.empty)
+
+          val result = TestParser.modelFromJsonHttpReads.read("GET", "/foo/bar", response)
+
+          result shouldBe Right(None)
+        }
+      }
+    }
 
       "return a Left" when {
 
@@ -68,19 +79,17 @@ class TraderKnownFactsHttpParserSpec extends TestBaseSpec with TraderKnownFactsF
 
           val response = HttpResponse(CONFLICT, body = "an error", headers = Map.empty)
 
-          withCaptureOfLoggingFrom(logger) {
-            logs =>
+          withCaptureOfLoggingFrom(logger) { logs =>
+            val result = TestParser.modelFromJsonHttpReads.read("GET", "/foo/bar", response)
 
-              val result = TestParser.modelFromJsonHttpReads.read("GET", "/foo/bar", response)
+            result shouldBe Left(UnexpectedDownstreamResponseError)
 
-              result shouldBe Left(UnexpectedDownstreamResponseError)
-
-              logs.exists(_.getMessage == "[TraderKnownFactsHttpParserSpec][modelFromJsonHttpReads] Received unexpected status: 409") shouldBe true
+            logs.exists(_.getMessage == "[TraderKnownFactsHttpParserSpec][modelFromJsonHttpReads] Received unexpected status: 409") shouldBe true
 
           }
 
         }
-      }
     }
   }
+
 }

--- a/test/uk/gov/hmrc/emcstfe/connectors/httpParsers/TraderKnownFactsHttpParserSpec.scala
+++ b/test/uk/gov/hmrc/emcstfe/connectors/httpParsers/TraderKnownFactsHttpParserSpec.scala
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.emcstfe.connectors.httpParsers
+
+import play.api.LoggerLike
+import play.api.http.Status._
+import play.api.libs.json.{Json, JsonValidationError}
+import uk.gov.hmrc.emcstfe.fixtures.TraderKnownFactsFixtures
+import uk.gov.hmrc.emcstfe.models.response.ErrorResponse.{TraderKnownFactsParsingError, UnexpectedDownstreamResponseError}
+import uk.gov.hmrc.emcstfe.support.TestBaseSpec
+import uk.gov.hmrc.emcstfe.utils.Logging
+import uk.gov.hmrc.http.HttpResponse
+import uk.gov.hmrc.play.bootstrap.tools.LogCapturing
+
+class TraderKnownFactsHttpParserSpec extends TestBaseSpec with TraderKnownFactsFixtures with LogCapturing with Logging {
+
+  val _logger: LoggerLike = logger
+
+  object TestParser extends TraderKnownFactsHttpParser {
+    override val logger: LoggerLike = _logger
+  }
+
+  ".modelFromJsonHttpReads" when {
+
+    s"an OK ($OK) response is received" must {
+
+      "return a Right" when {
+
+        "it contains valid Json" in {
+
+          val response = HttpResponse(OK, json = Json.parse(traderKnownFactsETDSJson), headers = Map.empty)
+
+          val result = TestParser.modelFromJsonHttpReads.read("GET", "/foo/bar", response)
+
+          result shouldBe Right(testTraderKnownFactsModel)
+        }
+      }
+
+      "return a Left" when {
+
+        "an OK response is returned but the body is invalid JSON" in {
+
+          val response = HttpResponse(OK, json = Json.obj(), headers = Map.empty)
+
+          val validationErrors = Seq(JsonValidationError(Seq("error.path.missing")), JsonValidationError(Seq("error.path.missing")))
+
+          val result = TestParser.modelFromJsonHttpReads.read("GET", "/foo/bar", response)
+
+          result shouldBe Left(TraderKnownFactsParsingError(validationErrors))
+
+        }
+
+        "an unknown response is returned" in {
+
+          val response = HttpResponse(CONFLICT, body = "an error", headers = Map.empty)
+
+          withCaptureOfLoggingFrom(logger) {
+            logs =>
+
+              val result = TestParser.modelFromJsonHttpReads.read("GET", "/foo/bar", response)
+
+              result shouldBe Left(UnexpectedDownstreamResponseError)
+
+              logs.exists(_.getMessage == "[TraderKnownFactsHttpParserSpec][modelFromJsonHttpReads] Received unexpected status: 409") shouldBe true
+
+          }
+
+        }
+      }
+    }
+  }
+}

--- a/test/uk/gov/hmrc/emcstfe/controllers/TraderKnownFactsControllerSpec.scala
+++ b/test/uk/gov/hmrc/emcstfe/controllers/TraderKnownFactsControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/emcstfe/controllers/TraderKnownFactsControllerSpec.scala
+++ b/test/uk/gov/hmrc/emcstfe/controllers/TraderKnownFactsControllerSpec.scala
@@ -35,14 +35,24 @@ class TraderKnownFactsControllerSpec extends TestBaseSpec with MockTraderKnownFa
 
   "GET /trader-known-facts" should {
     "return 200" when {
-      "service returns a Right" in {
+      "service returns a Right(Some(_))" in {
 
-        MockService.getTraderKnownFacts(testErn).returns(Future.successful(Right(testTraderKnownFactsModel)))
+        MockService.getTraderKnownFacts(testErn).returns(Future.successful(Right(Some(testTraderKnownFactsModel))))
 
         val result = controller.getTraderKnownFacts(testErn)(fakeRequest)
 
         status(result) shouldBe Status.OK
         contentAsJson(result) shouldBe Json.parse(testTraderKnownFactsJson)
+      }
+    }
+    "return 204" when {
+      "service returns a Right(None)" in {
+
+        MockService.getTraderKnownFacts(testErn).returns(Future.successful(Right(None)))
+
+        val result = controller.getTraderKnownFacts(testErn)(fakeRequest)
+
+        status(result) shouldBe Status.NO_CONTENT
       }
     }
     "return 500" when {

--- a/test/uk/gov/hmrc/emcstfe/controllers/TraderKnownFactsControllerSpec.scala
+++ b/test/uk/gov/hmrc/emcstfe/controllers/TraderKnownFactsControllerSpec.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.emcstfe.controllers
+
+import play.api.http.Status
+import play.api.libs.json.Json
+import play.api.test.Helpers._
+import play.api.test.{FakeRequest, Helpers}
+import uk.gov.hmrc.emcstfe.controllers.actions.FakeAuthAction
+import uk.gov.hmrc.emcstfe.fixtures.TraderKnownFactsFixtures
+import uk.gov.hmrc.emcstfe.mocks.services.MockTraderKnownFactsService
+import uk.gov.hmrc.emcstfe.models.response.ErrorResponse.UnexpectedDownstreamResponseError
+import uk.gov.hmrc.emcstfe.support.TestBaseSpec
+
+import scala.concurrent.Future
+
+class TraderKnownFactsControllerSpec extends TestBaseSpec with MockTraderKnownFactsService with TraderKnownFactsFixtures with FakeAuthAction {
+
+  private val fakeRequest = FakeRequest("GET", "/")
+  private val controller  = new TraderKnownFactsController(Helpers.stubControllerComponents(), mockService, FakeSuccessAuthAction)
+
+  "GET /trader-known-facts" should {
+    "return 200" when {
+      "service returns a Right" in {
+
+        MockService.getTraderKnownFacts(testErn).returns(Future.successful(Right(testTraderKnownFactsModel)))
+
+        val result = controller.getTraderKnownFacts(testErn)(fakeRequest)
+
+        status(result) shouldBe Status.OK
+        contentAsJson(result) shouldBe Json.parse(testTraderKnownFactsJson)
+      }
+    }
+    "return 500" when {
+      "service returns a Left" in {
+
+        MockService.getTraderKnownFacts(testErn).returns(Future.successful(Left(UnexpectedDownstreamResponseError)))
+
+        val result = controller.getTraderKnownFacts(testErn)(fakeRequest)
+
+        status(result) shouldBe Status.INTERNAL_SERVER_ERROR
+        contentAsJson(result) shouldBe Json.obj("message" -> UnexpectedDownstreamResponseError.message)
+      }
+    }
+  }
+
+}

--- a/test/uk/gov/hmrc/emcstfe/fixtures/TraderKnownFactsFixtures.scala
+++ b/test/uk/gov/hmrc/emcstfe/fixtures/TraderKnownFactsFixtures.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.emcstfe.fixtures
+
+import uk.gov.hmrc.emcstfe.models.response.TraderKnownFacts
+
+trait TraderKnownFactsFixtures {
+
+  val traderKnownFactsCandEJson: String =
+    """
+      |{
+      |  "traderName": "SEED TRADER 1629",
+      |  "addressLine1": "629 High Street",
+      |  "addressLine2": "Any Suburb",
+      |  "addressLine3": "Any Town",
+      |  "addressLine4": "Any County",
+      |  "addressLine5": "UK",
+      |  "postcode": "SS1 99AA"
+      |}
+      |""".stripMargin
+
+  val traderKnownFactsETDSJson: String =
+    """
+      |{
+      |  "businessName": "SEED TRADER 1629",
+      |  "addressLine1": "629 High Street",
+      |  "addressLine2": "Any Suburb",
+      |  "addressLine3": "Any Town",
+      |  "addressLine4": "Any County",
+      |  "addressLine5": "UK",
+      |  "postCode": "SS1 99AA"
+      |}
+      |""".stripMargin
+
+  val testTraderKnownFactsJson: String =
+    """
+      |{
+      |  "traderName": "SEED TRADER 1629",
+      |  "addressLine1": "629 High Street",
+      |  "addressLine2": "Any Suburb",
+      |  "addressLine3": "Any Town",
+      |  "addressLine4": "Any County",
+      |  "addressLine5": "UK",
+      |  "postcode": "SS1 99AA"
+      |}
+      |""".stripMargin
+
+  val testTraderKnownFactsModel: TraderKnownFacts = TraderKnownFacts(
+    traderName = "SEED TRADER 1629",
+    addressLine1 = Some("629 High Street"),
+    addressLine2 = Some("Any Suburb"),
+    addressLine3 = Some("Any Town"),
+    addressLine4 = Some("Any County"),
+    addressLine5 = Some("UK"),
+    postcode = Some("SS1 99AA")
+  )
+}

--- a/test/uk/gov/hmrc/emcstfe/mocks/connectors/MockHttpClient.scala
+++ b/test/uk/gov/hmrc/emcstfe/mocks/connectors/MockHttpClient.scala
@@ -49,6 +49,12 @@ trait MockHttpClient extends MockFactory {
         })
     }
 
+    def get[T](url: String): CallHandler[Future[T]] = {
+      (mockHttpClient
+        .GET(_: String, _: Seq[(String, String)], _: Seq[(String, String)])(_: HttpReads[T], _: HeaderCarrier, _: ExecutionContext))
+        .expects(url, *, *, *, *, *)
+    }
+
 
     def postString[T](url: String,
                       body: String,

--- a/test/uk/gov/hmrc/emcstfe/mocks/connectors/MockTraderKnownFactsConnector.scala
+++ b/test/uk/gov/hmrc/emcstfe/mocks/connectors/MockTraderKnownFactsConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/emcstfe/mocks/connectors/MockTraderKnownFactsConnector.scala
+++ b/test/uk/gov/hmrc/emcstfe/mocks/connectors/MockTraderKnownFactsConnector.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.emcstfe.mocks.connectors
+
+import org.scalamock.handlers.CallHandler3
+import org.scalamock.scalatest.MockFactory
+import uk.gov.hmrc.emcstfe.connectors.TraderKnownFactsConnector
+import uk.gov.hmrc.emcstfe.models.response._
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait MockTraderKnownFactsConnector extends MockFactory {
+
+  lazy val mockTraderKnownFactsConnector: TraderKnownFactsConnector = mock[TraderKnownFactsConnector]
+
+  object MockTraderKnownFactsConnector {
+
+    def getTraderKnownFacts(ern: String): CallHandler3[String, HeaderCarrier, ExecutionContext, Future[Either[ErrorResponse, TraderKnownFacts]]] = {
+      (mockTraderKnownFactsConnector
+        .getTraderKnownFacts(_: String)(_: HeaderCarrier, _: ExecutionContext))
+        .expects(ern, *, *)
+    }
+
+  }
+
+}

--- a/test/uk/gov/hmrc/emcstfe/mocks/connectors/MockTraderKnownFactsConnector.scala
+++ b/test/uk/gov/hmrc/emcstfe/mocks/connectors/MockTraderKnownFactsConnector.scala
@@ -30,7 +30,7 @@ trait MockTraderKnownFactsConnector extends MockFactory {
 
   object MockTraderKnownFactsConnector {
 
-    def getTraderKnownFacts(ern: String): CallHandler3[String, HeaderCarrier, ExecutionContext, Future[Either[ErrorResponse, TraderKnownFacts]]] = {
+    def getTraderKnownFacts(ern: String): CallHandler3[String, HeaderCarrier, ExecutionContext, Future[Either[ErrorResponse, Option[TraderKnownFacts]]]] = {
       (mockTraderKnownFactsConnector
         .getTraderKnownFacts(_: String)(_: HeaderCarrier, _: ExecutionContext))
         .expects(ern, *, *)

--- a/test/uk/gov/hmrc/emcstfe/mocks/services/MockTraderKnownFactsService.scala
+++ b/test/uk/gov/hmrc/emcstfe/mocks/services/MockTraderKnownFactsService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/emcstfe/mocks/services/MockTraderKnownFactsService.scala
+++ b/test/uk/gov/hmrc/emcstfe/mocks/services/MockTraderKnownFactsService.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.emcstfe.mocks.services
+
+import org.scalamock.handlers.CallHandler3
+import org.scalamock.scalatest.MockFactory
+import uk.gov.hmrc.emcstfe.models.response.{ErrorResponse, TraderKnownFacts}
+import uk.gov.hmrc.emcstfe.services.TraderKnownFactsService
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait MockTraderKnownFactsService extends MockFactory {
+  lazy val mockService: TraderKnownFactsService = mock[TraderKnownFactsService]
+
+  object MockService {
+
+    def getTraderKnownFacts(ern: String): CallHandler3[String, HeaderCarrier, ExecutionContext, Future[Either[ErrorResponse, TraderKnownFacts]]] = {
+      (mockService
+        .getTraderKnownFacts(_: String)(_: HeaderCarrier, _: ExecutionContext))
+        .expects(ern, *, *)
+    }
+
+  }
+
+}

--- a/test/uk/gov/hmrc/emcstfe/mocks/services/MockTraderKnownFactsService.scala
+++ b/test/uk/gov/hmrc/emcstfe/mocks/services/MockTraderKnownFactsService.scala
@@ -29,7 +29,7 @@ trait MockTraderKnownFactsService extends MockFactory {
 
   object MockService {
 
-    def getTraderKnownFacts(ern: String): CallHandler3[String, HeaderCarrier, ExecutionContext, Future[Either[ErrorResponse, TraderKnownFacts]]] = {
+    def getTraderKnownFacts(ern: String): CallHandler3[String, HeaderCarrier, ExecutionContext, Future[Either[ErrorResponse, Option[TraderKnownFacts]]]] = {
       (mockService
         .getTraderKnownFacts(_: String)(_: HeaderCarrier, _: ExecutionContext))
         .expects(ern, *, *)

--- a/test/uk/gov/hmrc/emcstfe/models/response/TraderKnownFactsSpec.scala
+++ b/test/uk/gov/hmrc/emcstfe/models/response/TraderKnownFactsSpec.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.emcstfe.models.response
+
+import play.api.libs.json.Json
+import uk.gov.hmrc.emcstfe.fixtures.TraderKnownFactsFixtures
+import uk.gov.hmrc.emcstfe.support.UnitSpec
+
+class TraderKnownFactsSpec extends UnitSpec with TraderKnownFactsFixtures {
+
+  "reads" should {
+    "read from emcs-tfe-reference-data" in {
+      Json.parse(traderKnownFactsCandEJson).as[TraderKnownFacts] shouldBe testTraderKnownFactsModel
+    }
+    "read from ETDS" in {
+      Json.parse(traderKnownFactsETDSJson).as[TraderKnownFacts] shouldBe testTraderKnownFactsModel
+    }
+  }
+
+  "writes" should {
+    "parse a model to JSON" in {
+      Json.toJson(testTraderKnownFactsModel) shouldBe Json.parse(testTraderKnownFactsJson)
+    }
+  }
+
+}

--- a/test/uk/gov/hmrc/emcstfe/services/TraderKnownFactsServiceSpec.scala
+++ b/test/uk/gov/hmrc/emcstfe/services/TraderKnownFactsServiceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/emcstfe/services/TraderKnownFactsServiceSpec.scala
+++ b/test/uk/gov/hmrc/emcstfe/services/TraderKnownFactsServiceSpec.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.emcstfe.services
+
+import uk.gov.hmrc.emcstfe.fixtures.TraderKnownFactsFixtures
+import uk.gov.hmrc.emcstfe.mocks.connectors.MockTraderKnownFactsConnector
+import uk.gov.hmrc.emcstfe.models.response.ErrorResponse.UnexpectedDownstreamResponseError
+import uk.gov.hmrc.emcstfe.support.TestBaseSpec
+
+import scala.concurrent.Future
+
+class TraderKnownFactsServiceSpec extends TestBaseSpec with TraderKnownFactsFixtures {
+
+  trait Test extends MockTraderKnownFactsConnector {
+    val service: TraderKnownFactsService = new TraderKnownFactsService(mockTraderKnownFactsConnector)
+  }
+
+  "getTraderKnownFacts" should {
+    "return a Right" when {
+      "connector call is successful and JSON is in the correct format" in new Test {
+
+        MockTraderKnownFactsConnector
+          .getTraderKnownFacts(testErn)
+          .returns(Future.successful(Right(testTraderKnownFactsModel)))
+
+        await(service.getTraderKnownFacts(testErn)) shouldBe Right(testTraderKnownFactsModel)
+      }
+    }
+
+    "return a Left" when {
+      "connector call is unsuccessful" in new Test {
+
+        MockTraderKnownFactsConnector
+          .getTraderKnownFacts(testErn)
+          .returns(Future.successful(Left(UnexpectedDownstreamResponseError)))
+
+        await(service.getTraderKnownFacts(testErn)) shouldBe Left(UnexpectedDownstreamResponseError)
+      }
+    }
+  }
+
+}

--- a/test/uk/gov/hmrc/emcstfe/services/TraderKnownFactsServiceSpec.scala
+++ b/test/uk/gov/hmrc/emcstfe/services/TraderKnownFactsServiceSpec.scala
@@ -35,9 +35,9 @@ class TraderKnownFactsServiceSpec extends TestBaseSpec with TraderKnownFactsFixt
 
         MockTraderKnownFactsConnector
           .getTraderKnownFacts(testErn)
-          .returns(Future.successful(Right(testTraderKnownFactsModel)))
+          .returns(Future.successful(Right(Some(testTraderKnownFactsModel))))
 
-        await(service.getTraderKnownFacts(testErn)) shouldBe Right(testTraderKnownFactsModel)
+        await(service.getTraderKnownFacts(testErn)) shouldBe Right(Some(testTraderKnownFactsModel))
       }
     }
 


### PR DESCRIPTION
Related PR(s):

- https://github.com/hmrc/app-config-base/pull/11021
- https://github.com/hmrc/app-config-qa/pull/23362
- https://github.com/hmrc/app-config-staging/pull/15990
- https://github.com/hmrc/app-config-production/pull/23395
- https://github.com/hmrc/emcs-tfe-reference-data-stub/pull/36
