### PR TITLE
[ETFE-4622] Add mongo cache for Known Facts response from ETDS18

### DIFF
--- a/app/uk/gov/hmrc/emcstfe/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/emcstfe/config/AppConfig.scala
@@ -65,6 +65,9 @@ class AppConfig @Inject() (servicesConfig: ServicesConfig, configuration: Config
   def getMovementTTL(): Duration           = Duration(configuration.get[String]("mongodb.getMovement.TTL"))
   def getMovementReplaceIndexes(): Boolean = configuration.get[Boolean]("mongodb.getMovement.replaceIndexes")
 
+  def knownFactsTTL(): Duration           = Duration(configuration.get[String]("mongodb.knownFacts.TTL"))
+  def knownFactsReplaceIndexes(): Boolean = configuration.get[Boolean]("mongodb.knownFacts.replaceIndexes")
+
   def getFeatureSwitchValue(feature: String): Boolean = configuration.get[Boolean](feature)
 
   def eisBaseUrl: String = if (isEnabled(UseDownstreamStub)) downstreamStubUrl else eisUrl

--- a/app/uk/gov/hmrc/emcstfe/models/mongo/KnownFacts.scala
+++ b/app/uk/gov/hmrc/emcstfe/models/mongo/KnownFacts.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import java.time.Instant
 
 final case class KnownFacts(ern: String,
                             knownFacts: TraderKnownFacts,
-                            lastUpdated: Instant)
+                            lastUpdated: Instant = Instant.now)
 
 object KnownFacts {
 

--- a/app/uk/gov/hmrc/emcstfe/models/mongo/KnownFacts.scala
+++ b/app/uk/gov/hmrc/emcstfe/models/mongo/KnownFacts.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.emcstfe.models.mongo
+
+import play.api.libs.functional.syntax._
+import play.api.libs.json._
+import uk.gov.hmrc.emcstfe.models.response.TraderKnownFacts
+import uk.gov.hmrc.mongo.play.json.formats.MongoJavatimeFormats
+
+import java.time.Instant
+
+final case class KnownFacts(ern: String,
+                            knownFacts: TraderKnownFacts,
+                            lastUpdated: Instant)
+
+object KnownFacts {
+
+  private val mongoReads: Reads[KnownFacts] = (
+    (__ \ "ern").read[String] and
+      (__ \ "knownFacts").read[TraderKnownFacts] and
+      (__ \ "lastUpdated").read(MongoJavatimeFormats.instantFormat)
+    )(KnownFacts.apply _)
+
+  private val mongoWrites: OWrites[KnownFacts] = (
+    (__ \ "ern").write[String] and
+      (__ \ "knownFacts").write[TraderKnownFacts] and
+      (__ \ "lastUpdated").write(MongoJavatimeFormats.instantFormat)
+    )(unlift(KnownFacts.unapply))
+
+  val mongoFormat: OFormat[KnownFacts] = OFormat(mongoReads, mongoWrites)
+}

--- a/app/uk/gov/hmrc/emcstfe/models/response/TraderKnownFacts.scala
+++ b/app/uk/gov/hmrc/emcstfe/models/response/TraderKnownFacts.scala
@@ -32,5 +32,8 @@ object TraderKnownFacts {
       ((__ \ "postcode").read[String].map(Some(_)) or (__ \ "postCode").readNullable[String])
     )(TraderKnownFacts.apply _)
 
-    implicit val writes: OWrites[TraderKnownFacts] = Json.writes[TraderKnownFacts]
+  implicit val writes: OWrites[TraderKnownFacts] = Json.writes[TraderKnownFacts]
+
+  val format: OFormat[TraderKnownFacts] = OFormat(reads, writes)
+
 }

--- a/app/uk/gov/hmrc/emcstfe/models/response/TraderKnownFacts.scala
+++ b/app/uk/gov/hmrc/emcstfe/models/response/TraderKnownFacts.scala
@@ -32,8 +32,5 @@ object TraderKnownFacts {
       ((__ \ "postcode").read[String].map(Some(_)) or (__ \ "postCode").readNullable[String])
     )(TraderKnownFacts.apply _)
 
-  implicit val writes: OWrites[TraderKnownFacts] = Json.writes[TraderKnownFacts]
-
-  val format: OFormat[TraderKnownFacts] = OFormat(reads, writes)
-
+    implicit val writes: OWrites[TraderKnownFacts] = Json.writes[TraderKnownFacts]
 }

--- a/app/uk/gov/hmrc/emcstfe/repositories/KnownFactsRepository.scala
+++ b/app/uk/gov/hmrc/emcstfe/repositories/KnownFactsRepository.scala
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.emcstfe.repositories
+
+import com.google.inject.ImplementedBy
+import org.mongodb.scala.bson.conversions.Bson
+import org.mongodb.scala.model._
+import play.api.libs.json.Format
+import uk.gov.hmrc.emcstfe.config.AppConfig
+import uk.gov.hmrc.emcstfe.models.mongo.KnownFacts
+import uk.gov.hmrc.emcstfe.repositories.KnownFactsRepository._
+import uk.gov.hmrc.emcstfe.utils.TimeMachine
+import uk.gov.hmrc.mongo.MongoComponent
+import uk.gov.hmrc.mongo.play.json.PlayMongoRepository
+import uk.gov.hmrc.mongo.play.json.formats.MongoJavatimeFormats
+
+import java.time.Instant
+import java.util.concurrent.TimeUnit
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.duration.Duration
+import scala.concurrent.{ExecutionContext, Future}
+
+@ImplementedBy(classOf[KnownFactsRepositoryImpl])
+trait KnownFactsRepository {
+  def get(ern: String): Future[Option[KnownFacts]]
+  def set(answers: KnownFacts): Future[Boolean]
+}
+
+@Singleton
+class KnownFactsRepositoryImpl @Inject() (mongoComponent: MongoComponent, appConfig: AppConfig, time: TimeMachine)(implicit ec: ExecutionContext)
+    extends PlayMongoRepository[KnownFacts](
+      collectionName = KnownFactsRepository.collectionName,
+      mongoComponent = mongoComponent,
+      domainFormat = KnownFacts.mongoFormat,
+      indexes = mongoIndexes(appConfig.knownFactsTTL()),
+      replaceIndexes = appConfig.knownFactsReplaceIndexes()
+    ) with KnownFactsRepository {
+
+  implicit val instantFormat: Format[Instant] = MongoJavatimeFormats.instantFormat
+
+  private def byErn(ern: String): Bson =
+    Filters.equal(ernField, ern)
+
+  def get(ern: String): Future[Option[KnownFacts]] =
+    collection.find(byErn(ern)).headOption()
+
+  def set(knownFacts: KnownFacts): Future[Boolean] = {
+    collection
+      .replaceOne(
+        filter = byErn(knownFacts.ern),
+        replacement = knownFacts copy (lastUpdated = time.instant()),
+        options = ReplaceOptions().upsert(true)
+      )
+      .toFuture()
+      .map(_ => true)
+  }
+}
+
+object KnownFactsRepository {
+
+  val collectionName    = "known-facts"
+  val ernField          = "ern"
+  val lastUpdatedField  = "lastUpdated"
+
+  def mongoIndexes(ttl: Duration): Seq[IndexModel] = Seq(
+    IndexModel(
+      Indexes.ascending(lastUpdatedField),
+      IndexOptions()
+        .name(s"${lastUpdatedField}Idx")
+        .expireAfter(ttl.toSeconds, TimeUnit.SECONDS)
+    ),
+    IndexModel(
+      Indexes.ascending(ernField),
+      IndexOptions()
+        .unique(true)
+        .name(s"${ernField}Idx")
+    )
+  )
+
+}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -100,6 +100,10 @@ mongodb {
     replaceIndexes = true
     maxTemplates = 30
   }
+  knownFacts {
+    TTL = 1hour
+    replaceIndexes = true
+  }
 }
 
 microservice {

--- a/it/uk/gov/hmrc/emcstfe/repositories/KnownFactsRepositorySpec.scala
+++ b/it/uk/gov/hmrc/emcstfe/repositories/KnownFactsRepositorySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,7 +52,7 @@ class KnownFactsRepositorySpec extends RepositoryBaseSpec[KnownFacts] with BaseF
 
     "insert when no template exists and set the last updated time" in {
 
-      repository.set(knownFacts).futureValue
+      repository.set(testErn, testTraderKnownFactsModel).futureValue
 
       val expectedResult = knownFacts copy (lastUpdated = instantNow)
       val updatedRecord = repository.get(testErn).futureValue.get
@@ -63,7 +63,7 @@ class KnownFactsRepositorySpec extends RepositoryBaseSpec[KnownFacts] with BaseF
     "upsert when template already exists and update the last updated time" in {
 
       insert(knownFacts).futureValue
-      repository.set(knownFacts).futureValue
+      repository.set(testErn, testTraderKnownFactsModel).futureValue
 
       val expectedResult = knownFacts copy (lastUpdated = instantNow)
       val updatedRecord = repository.get(testErn).futureValue.value

--- a/it/uk/gov/hmrc/emcstfe/repositories/KnownFactsRepositorySpec.scala
+++ b/it/uk/gov/hmrc/emcstfe/repositories/KnownFactsRepositorySpec.scala
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.emcstfe.repositories
+
+import org.mongodb.scala.Document
+import uk.gov.hmrc.emcstfe.fixtures.{BaseFixtures, TraderKnownFactsFixtures}
+import uk.gov.hmrc.emcstfe.models.mongo.KnownFacts
+import uk.gov.hmrc.emcstfe.utils.TimeMachine
+
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+class KnownFactsRepositorySpec extends RepositoryBaseSpec[KnownFacts] with BaseFixtures with TraderKnownFactsFixtures {
+
+  override def checkTtlIndex: Boolean = false
+
+  private val instantNow = Instant.now.truncatedTo(ChronoUnit.MILLIS)
+  private val timeMachine: TimeMachine = () => instantNow
+
+  val knownFacts: KnownFacts = KnownFacts(
+    ern = testErn,
+    knownFacts = testTraderKnownFactsModel,
+    lastUpdated = Instant.ofEpochSecond(1)
+  )
+
+  protected override val repository = new KnownFactsRepositoryImpl(
+    mongoComponent = mongoComponent,
+    appConfig = mockAppConfig,
+    time = timeMachine
+  )
+
+  override protected def beforeEach(): Unit = {
+    super.afterEach()
+    repository.collection.deleteMany(Document()).toFuture().futureValue
+  }
+
+  ".set" must {
+
+    "insert when no template exists and set the last updated time" in {
+
+      repository.set(knownFacts).futureValue
+
+      val expectedResult = knownFacts copy (lastUpdated = instantNow)
+      val updatedRecord = repository.get(testErn).futureValue.get
+
+      updatedRecord shouldBe expectedResult
+    }
+
+    "upsert when template already exists and update the last updated time" in {
+
+      insert(knownFacts).futureValue
+      repository.set(knownFacts).futureValue
+
+      val expectedResult = knownFacts copy (lastUpdated = instantNow)
+      val updatedRecord = repository.get(testErn).futureValue.value
+
+      updatedRecord shouldBe expectedResult
+    }
+  }
+
+  ".get" when {
+
+    "there is a known facts response for this ern" must {
+
+      "return Some(known facts)" in {
+
+        insert(knownFacts).futureValue
+
+        val result = repository.get(testErn).futureValue
+
+        result shouldBe Some(knownFacts)
+      }
+    }
+
+    "there is no known facts for this ern" must {
+
+      "return None" in {
+        repository.get(testErn).futureValue shouldBe None
+      }
+    }
+  }
+}

--- a/test/uk/gov/hmrc/emcstfe/mocks/repository/MockKnownFactsRepository.scala
+++ b/test/uk/gov/hmrc/emcstfe/mocks/repository/MockKnownFactsRepository.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.emcstfe.mocks.repository
+
+import org.scalamock.handlers.{CallHandler1, CallHandler2}
+import org.scalamock.scalatest.MockFactory
+import uk.gov.hmrc.emcstfe.models.mongo.KnownFacts
+import uk.gov.hmrc.emcstfe.models.response.TraderKnownFacts
+import uk.gov.hmrc.emcstfe.repositories.KnownFactsRepository
+
+import scala.concurrent.Future
+
+trait MockKnownFactsRepository extends MockFactory {
+
+  lazy val mockKnownFactsRepository: KnownFactsRepository = mock[KnownFactsRepository]
+
+  object MockKnownFactsRepository {
+    def set(ern: String, traderKnownFacts: TraderKnownFacts): CallHandler2[String, TraderKnownFacts, Future[Boolean]] =
+      (mockKnownFactsRepository.set(_: String, _: TraderKnownFacts)).expects(ern, traderKnownFacts)
+
+    def get(ern: String): CallHandler1[String, Future[Option[KnownFacts]]] =
+      (mockKnownFactsRepository.get(_: String)).expects(ern)
+  }
+}
+
+

--- a/test/uk/gov/hmrc/emcstfe/services/TraderKnownFactsServiceSpec.scala
+++ b/test/uk/gov/hmrc/emcstfe/services/TraderKnownFactsServiceSpec.scala
@@ -20,49 +20,113 @@ import uk.gov.hmrc.emcstfe.config.AppConfig
 import uk.gov.hmrc.emcstfe.featureswitch.core.config.{EnableKnownFactsViaETDS18, FeatureSwitching}
 import uk.gov.hmrc.emcstfe.fixtures.TraderKnownFactsFixtures
 import uk.gov.hmrc.emcstfe.mocks.connectors.{MockEisConnector, MockTraderKnownFactsConnector}
+import uk.gov.hmrc.emcstfe.mocks.repository.MockKnownFactsRepository
+import uk.gov.hmrc.emcstfe.models.mongo.KnownFacts
 import uk.gov.hmrc.emcstfe.models.response.ErrorResponse.UnexpectedDownstreamResponseError
 import uk.gov.hmrc.emcstfe.support.TestBaseSpec
+import uk.gov.hmrc.play.bootstrap.tools.LogCapturing
 
 import scala.concurrent.Future
 
-class TraderKnownFactsServiceSpec extends TestBaseSpec with TraderKnownFactsFixtures {
+class TraderKnownFactsServiceSpec extends TestBaseSpec
+  with TraderKnownFactsFixtures
+  with MockTraderKnownFactsConnector
+  with MockEisConnector
+  with FeatureSwitching
+  with MockKnownFactsRepository
+  with LogCapturing {
 
-  trait Test extends MockTraderKnownFactsConnector with MockEisConnector with FeatureSwitching {
     lazy val config: AppConfig           = app.injector.instanceOf[AppConfig]
-    val service: TraderKnownFactsService = new TraderKnownFactsService(mockTraderKnownFactsConnector, mockEisConnector, config)
-  }
+    lazy val service: TraderKnownFactsService = new TraderKnownFactsService(
+      mockTraderKnownFactsConnector,
+      mockEisConnector,
+      mockKnownFactsRepository,
+      config
+    )
 
   "getTraderKnownFacts" when {
-    "calling ETDS" should {
+    "calling ETDS" when {
+      "a known facts response exists in the cache" when {
+        "the call to retrieve from Mongo is successful" should {
+          "return from the cache without calling ETDS18" in {
 
-      "return a Right" when {
-        "connector call is successful and JSON is in the correct format" in new Test {
-          enable(EnableKnownFactsViaETDS18)
+            enable(EnableKnownFactsViaETDS18)
 
-          MockEisConnector
-            .getTraderKnownFactsViaETDS18(testErn)
-            .returns(Future.successful(Right(Some(testTraderKnownFactsModel))))
+            MockKnownFactsRepository.get(testErn).returns(Future.successful(Some(KnownFacts(testErn, testTraderKnownFactsModel))))
+            MockEisConnector.getTraderKnownFactsViaETDS18(testErn).never()
 
-          await(service.getTraderKnownFacts(testErn)) shouldBe Right(Some(testTraderKnownFactsModel))
+            await(service.getTraderKnownFacts(testErn)) shouldBe Right(Some(testTraderKnownFactsModel))
+          }
+        }
+        "the call to retrieve from Mongo fails" should {
+          "attempt to retrieve from ETDS18 (logging the mongo future failure as an error)" in {
+
+            enable(EnableKnownFactsViaETDS18)
+
+            MockKnownFactsRepository.get(testErn).returns(Future.failed(new Exception("bang")))
+            MockKnownFactsRepository.set(testErn, testTraderKnownFactsModel).returns(Future.successful(true))
+
+            MockEisConnector
+              .getTraderKnownFactsViaETDS18(testErn)
+              .returns(Future.successful(Right(Some(testTraderKnownFactsModel))))
+
+            withCaptureOfLoggingFrom(service.logger) { logs =>
+              await(service.getTraderKnownFacts(testErn)) shouldBe Right(Some(testTraderKnownFactsModel))
+              logs.exists(_.getMessage.contains("Unexpected response from Mongo, attempting to retrieve latest Known Facts from ETDS18")) shouldBe true
+            }
+          }
         }
       }
+      "a known facts response does NOT exist in the cache" should {
+        "return a Right" when {
+          "connector call is successful and JSON is in the correct format (storing the KF response successfully)" in {
+            enable(EnableKnownFactsViaETDS18)
 
-      "return a Left" when {
-        "connector call is unsuccessful" in new Test {
-          enable(EnableKnownFactsViaETDS18)
+            MockKnownFactsRepository.get(testErn).returns(Future.successful(None))
+            MockKnownFactsRepository.set(testErn, testTraderKnownFactsModel).returns(Future.successful(true))
 
-          MockEisConnector
-            .getTraderKnownFactsViaETDS18(testErn)
-            .returns(Future.successful(Left(UnexpectedDownstreamResponseError)))
+            MockEisConnector
+              .getTraderKnownFactsViaETDS18(testErn)
+              .returns(Future.successful(Right(Some(testTraderKnownFactsModel))))
 
-          await(service.getTraderKnownFacts(testErn)) shouldBe Left(UnexpectedDownstreamResponseError)
+            await(service.getTraderKnownFacts(testErn)) shouldBe Right(Some(testTraderKnownFactsModel))
+          }
+        }
+
+        "return a Left" when {
+          "connector call is unsuccessful" in {
+            enable(EnableKnownFactsViaETDS18)
+
+            MockKnownFactsRepository.get(testErn).returns(Future.successful(None))
+
+            MockEisConnector
+              .getTraderKnownFactsViaETDS18(testErn)
+              .returns(Future.successful(Left(UnexpectedDownstreamResponseError)))
+
+            await(service.getTraderKnownFacts(testErn)) shouldBe Left(UnexpectedDownstreamResponseError)
+          }
+
+          "connector fails future (logging an warning message)" in {
+            enable(EnableKnownFactsViaETDS18)
+
+            MockKnownFactsRepository.get(testErn).returns(Future.successful(None))
+
+            MockEisConnector
+              .getTraderKnownFactsViaETDS18(testErn)
+              .returns(Future.failed(new Exception("bang")))
+
+            withCaptureOfLoggingFrom(service.logger) { logs =>
+              await(service.getTraderKnownFacts(testErn)) shouldBe Left(UnexpectedDownstreamResponseError)
+              logs.exists(_.getMessage.contains("Unexpected error when retrieving known facts from ETDS18")) shouldBe true
+            }
+          }
         }
       }
     }
     "calling emcs-tfe-reference-data" should {
 
       "return a Right" when {
-        "connector call is successful and JSON is in the correct format" in new Test {
+        "connector call is successful and JSON is in the correct format" in {
           disable(EnableKnownFactsViaETDS18)
 
           MockTraderKnownFactsConnector
@@ -74,7 +138,7 @@ class TraderKnownFactsServiceSpec extends TestBaseSpec with TraderKnownFactsFixt
       }
 
       "return a Left" when {
-        "connector call is unsuccessful" in new Test {
+        "connector call is unsuccessful" in {
           disable(EnableKnownFactsViaETDS18)
 
           MockTraderKnownFactsConnector


### PR DESCRIPTION
App-Config-PR(s):
- https://github.com/hmrc/app-config-qa/pull/23730
- https://github.com/hmrc/app-config-staging/pull/16171
- https://github.com/hmrc/app-config-production/pull/23658